### PR TITLE
remove unnecessary try/catch

### DIFF
--- a/index.js
+++ b/index.js
@@ -907,7 +907,12 @@ Session.prototype.onError = function (error) {
 };
 
 Session.prototype.onMsg = function (buffer, remote) {
-	var message = new ResponseMessage (buffer);
+	try {
+		var message = new ResponseMessage (buffer);
+	} catch (error) {
+		this.emit ("error", error);
+		return;
+	}
 
 	var req = this.unregisterRequest (message.pdu.id);
 	if (! req)

--- a/index.js
+++ b/index.js
@@ -1058,12 +1058,7 @@ Session.prototype.simpleGet = function (pduClass, feedCb, varbinds,
 		port: (options && options.port) ? options.port : this.port
 	};
 
-	try {
-		this.send (req);
-	} catch (error) {
-		if (req.responseCb)
-			req.responseCb (error);
-	}
+	this.send (req);
 };
 
 function subtreeCb (req, varbinds) {
@@ -1321,12 +1316,7 @@ Session.prototype.trap = function () {
 		port: this.trapPort
 	};
 
-	try {
-		this.send (req, true);
-	} catch (error) {
-		if (req.responseCb)
-			req.responseCb (error);
-	}
+	this.send (req, true);
 
 	return this;
 };


### PR DESCRIPTION
First, thank you for this great library.

I got bitten by the fact that it calls user code inside try blocks. This created an extremely difficult to debug situation caused not by a bug in this library, but by a bug in one of my callbacks!

It's not the first time this has happened to me and I've learned generally that try/catch should only be used to wrap sync code that executes outside the js main thread (in this case, dgram.send) - if there are bugs in thread where we can fix them, I say we should not hesitate to readily crash programs so that they might all be revealed.

That said, I've been running your code as patched here without issue for a few days. I know the diff looks super confusing, however all it does it remove try catch except around dgram.send calls as mentioned above.