### PR TITLE
Fix issue where some agents use a 2nd report PDU to perform time synchronization

### DIFF
--- a/index.js
+++ b/index.js
@@ -1963,6 +1963,13 @@ Session.prototype.onMsg = function (buffer) {
 						return;
 					}
 					req.originalPdu.contextName = this.context;
+
+					if ( ! message.msgSecurityParameters.msgAuthoritativeEngineBoots && ! message.msgSecurityParameters.msgAuthoritativeEngineTime) {
+						// time has not been synchronized by the first report PDU, therefore we expect this
+						// request to also generate a report with the time synchronization
+						this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port, true);
+						return;
+					}
 					this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port);
 				}
 			} else if ( this.proxy ) {
@@ -2485,11 +2492,14 @@ Session.prototype.walk  = function () {
 	return this;
 };
 
-Session.prototype.sendV3Req = function (pdu, feedCb, responseCb, options, port) {
+Session.prototype.sendV3Req = function (pdu, feedCb, responseCb, options, port, storeOriginalPdu) {
 	var message = Message.createRequestV3 (this.user, this.msgSecurityParameters, pdu);
 	var reqOptions = options || {};
 	var req = new Req (this, message, feedCb, responseCb, reqOptions);
 	req.port = port;
+	if (storeOriginalPdu) {
+		req.originalPdu = pdu;
+	}
 	this.send (req);
 };
 


### PR DESCRIPTION
For me at least this fixes: https://github.com/markabrahams/node-net-snmp/issues/64

Issue is that some devices do not set the `msgAuthoritativeEngineBoots` and `msgAuthoritativeEngineTime` fields on the first report PDU in response to initial discovery, and a second request / report is required to get those before the actual request can proceed.

A possible simpler change would be to always store the original PDU on the req, as in this patch:

```
diff --git a/index.js b/index.js
index aba8bf1..eef7d3b 100644
--- a/index.js
+++ b/index.js
@@ -2490,6 +2490,7 @@ Session.prototype.sendV3Req = function (pdu, feedCb, responseCb, options, port)
        var reqOptions = options || {};
        var req = new Req (this, message, feedCb, responseCb, reqOptions);
        req.port = port;
+       req.originalPdu = pdu;
        this.send (req);
 };
```

but that does open up the possibility of a request loop I think, so I went for this route instead.