### PR TITLE
Handle periodic report PDU packets on a long running session

### DIFF
--- a/index.js
+++ b/index.js
@@ -1958,19 +1958,13 @@ Session.prototype.onMsg = function (buffer) {
 					this.msgSecurityParameters.msgAuthenticationParameters = "";
 					this.msgSecurityParameters.msgPrivacyParameters = "";
 				} else {
-					if ( ! req.originalPdu ) {
+					if ( ! req.originalPdu || ! req.allowReport ) {
 						req.responseCb (new ResponseInvalidError ("Unexpected Report PDU") );
 						return;
 					}
 					req.originalPdu.contextName = this.context;
-
-					if ( ! message.msgSecurityParameters.msgAuthoritativeEngineBoots && ! message.msgSecurityParameters.msgAuthoritativeEngineTime) {
-						// time has not been synchronized by the first report PDU, therefore we expect this
-						// request to also generate a report with the time synchronization
-						this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port, true);
-					} else {
-						this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port, false);
-					}
+					let timeSyncNeeded = !message.msgSecurityParameters.msgAuthoritativeEngineBoots || !message.msgSecurityParameters.msgAuthoritativeEngineTime;
+					this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port, timeSyncNeeded);
 				}
 			} else if ( this.proxy ) {
 				this.onProxyResponse (req, message);
@@ -2109,7 +2103,7 @@ Session.prototype.simpleGet = function (pduClass, feedCb, varbinds,
 
 		if ( this.version == Version3 ) {
 			if ( this.msgSecurityParameters ) {
-				this.sendV3Req (pdu, feedCb, responseCb, options, this.port, false);
+				this.sendV3Req (pdu, feedCb, responseCb, options, this.port, true);
 			} else {
 				this.sendV3Discovery (pdu, feedCb, responseCb, options);
 			}
@@ -2492,14 +2486,13 @@ Session.prototype.walk  = function () {
 	return this;
 };
 
-Session.prototype.sendV3Req = function (pdu, feedCb, responseCb, options, port, storeOriginalPdu) {
+Session.prototype.sendV3Req = function (pdu, feedCb, responseCb, options, port, allowReport) {
 	var message = Message.createRequestV3 (this.user, this.msgSecurityParameters, pdu);
 	var reqOptions = options || {};
 	var req = new Req (this, message, feedCb, responseCb, reqOptions);
 	req.port = port;
-	if (storeOriginalPdu) {
-		req.originalPdu = pdu;
-	}
+	req.originalPdu = pdu;
+	req.allowReport = allowReport;
 	this.send (req);
 };
 
@@ -2508,6 +2501,7 @@ Session.prototype.sendV3Discovery = function (originalPdu, feedCb, responseCb, o
 	var discoveryMessage = Message.createDiscoveryV3 (discoveryPdu);
 	var discoveryReq = new Req (this, discoveryMessage, feedCb, responseCb, options);
 	discoveryReq.originalPdu = originalPdu;
+	discoveryReq.allowReport = true;
 	this.send (discoveryReq);
 }
 


### PR DESCRIPTION
OK, this fixes https://github.com/markabrahams/node-net-snmp/issues/68 for me, without breaking the initial double report PDU handling unlike my previous attempt in https://github.com/markabrahams/node-net-snmp/pull/69. Have tested against 2 Cisco devices and a unix machine using the standard net-snmp library successfully.

There's a flag on the req to say whether we allow a report PDU to be the response or not - it is true for initial discovery requests, true if we receive a report PDU without the time sync fields set, and true for normal requests, but false if we just received a report PDU with the time fields, to avoid us allowing a loop where we keep sending a request and the device keeps replying with a report. See what you think...