### PR TITLE
Support for absolute Windows paths

### DIFF
--- a/lib/mib.js
+++ b/lib/mib.js
@@ -156,7 +156,7 @@ var MIB = function (dir) {
         },
         Import: function (FileName) {
             var filePath;
-            if ( FileName.startsWith('/') ) {
+            if ( FileName.startsWith('/') || /^[a-zA-Z]:\\/.test(FileName) ) {
                 filePath = FileName;
             } else {
                 filePath = __dirname + '/' + FileName;


### PR DESCRIPTION
This adds support for Windows absolute paths (generated by `path.resolve(relativePath);`. The regex checks for a string starting with a letter (drive letter) followed by a colon followed by a back slash (Windows uses back slashes where Linux uses forward slashes).

Fixes #74 