### PR TITLE
Add babel into the build step to transpile for support for older NodeJS versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 notes.txt
+index_dist.js

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ TODO
 .hgignore
 .hgtags
 node_modules
+index.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const path = require('path');
+
+const settings = {
+  "presets": [
+    [
+      "@babel/env",
+      {
+        "targets": {
+          "node": "6.9.5"
+        },
+        "corejs": "3.6.5",
+        "useBuiltIns": "usage"
+      }
+    ]
+  ]
+};
+
+module.exports = settings;
+

--- a/package.json
+++ b/package.json
@@ -2,15 +2,23 @@
   "name": "net-snmp",
   "version": "2.6.3",
   "description": "JavaScript implementation of the Simple Network Management Protocol (SNMP)",
-  "main": "index.js",
+  "main": "index_dist.js",
+  "scripts": {
+    "build": "./node_modules/.bin/babel index.js --out-file index_dist.js",
+    "prepublish": "npm run build"
+  },
   "directories": {
     "example": "example"
   },
   "dependencies": {
     "asn1-ber": "*",
+    "core-js": "^3.6.5",
     "smart-buffer": "^4.1.0"
   },
   "devDependencies": {
+    "@babel/cli": "^7.8.4",
+    "@babel/core": "^7.9.6",
+    "@babel/preset-env": "^7.9.6",
     "getopts": "*"
   },
   "contributors": [


### PR DESCRIPTION
Overview:
This PR adds support for older NodeJS and Javascript versions. For my particular use-case, I need to support back to NodeJS 6.9.5. However, I feel confident that others will benefit from the older browser support that would be gained in the process.

I don't know if this fits with the vision of the project, so no worries if you'd rather not accept this.

Modifications:
- Add babel into build step
- Create index_dist.js which is the default entry point for the
  distributed npm module
- Add prepublish step
- Add index.js to .npmignore

