### PR TITLE
Fix for undeclared scopedPdu

### DIFF
--- a/index.js
+++ b/index.js
@@ -1544,7 +1544,7 @@ Message.createFromBuffer = function (buffer, user) {
 		message.msgSecurityParameters.msgUserName = msgSecurityParametersReader.readString ();
 		message.msgSecurityParameters.msgAuthenticationParameters = Buffer.from(msgSecurityParametersReader.readString (ber.OctetString, true));
 		message.msgSecurityParameters.msgPrivacyParameters = Buffer.from(msgSecurityParametersReader.readString (ber.OctetString, true));
-		scopedPdu = true;
+		message.pdu = readPdu(reader, true);
 
 		if ( message.hasPrivacy() ) {
 			message.encryptedPdu = reader.readString (ber.OctetString, true);


### PR DESCRIPTION
scopedPdu was an undeclared variable in this instance. I took a look at some recent changes, and I think this was the intended change.

In all honesty, I kind of guessed on what the intended fix was here. I don't fully follow the codepath here, but I saw a recent change that suggests this was the intention. Let me know if this looks ok.