### PR TITLE
Bug fix for when the index value contains 0

### DIFF
--- a/index.js
+++ b/index.js
@@ -3160,7 +3160,7 @@ MibNode.prototype.getInstanceNodeForTableRowIndex = function (index) {
 			return this.getInstanceNodeForTableRow();
 		} else {
 			var nextChildIndexPart = index[0];
-			if ( ! nextChildIndexPart ) {
+			if ( nextChildIndexPart == null ) {
 				return null;
 			}
 			remainingIndex = index.slice(1);


### PR DESCRIPTION
I had a single index table like follows:

```js
var myTableProvider = {
  name: 'smallIfTable',
  type: MibProviderType.Table,
  oid: '1.3.6.1.2.1.2.2.1',
  tableColumns: [
    {
      number: 1,
      name: 'ifIndex',
      type: ObjectType.Integer,
    },
    {
      number: 2,
      name: 'ifDescr',
      type: ObjectType.Integer,
    },
    {
      number: 3,
      name: 'ifType',
      type: ObjectType.Integer,
    },
  ],
  tableIndex: [
    {
      columnName: 'ifIndex',
    },
  ],
};
var mib = agent.getMib();
mib.registerProvider(myTableProvider);

mib.addTableRow('smallIfTable', [0, 10, 6]); // of interest
mib.addTableRow('smallIfTable', [2, 11, 6]);
mib.addTableRow('smallIfTable', [3, 12, 8]);
```

My first row had the value `0` for the index column, when I called row specific methods with `rowIndex: [0]`, it would throw an error. This was because of a falsy check instead of a null check (0 is falsy), all i did was change that. 

Let me know if this was intentional and 0 is not a valid index for some reason.