### PR TITLE
Add eslint for linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,33 @@
+{
+  "extends": "airbnb",
+  "rules": {
+    "func-names": ["error", "never"],
+    /*"linebreak-style": ["error", "windows"] */
+    "linebreak-style": 0,
+    "no-param-reassign": 0,
+    "no-console": 0,
+    "no-unused-expressions": ["error", { "allowShortCircuit": true, "allowTernary": true }],
+    "import/no-extraneous-dependencies": ["error", {"devDependencies": true}],
+    /* "arrow-parens": ["error", "as-needed"], */
+    "arrow-parens": 0,
+    "arrow-body-style": 0,
+    "prefer-destructuring": ["warn", {
+      "array": false,
+      "object": true
+    }],
+    no-plusplus: ["error", { "allowForLoopAfterthoughts": true }],
+    "comma-dangle": 0,
+    "curly": ["error", "all"],
+    /*no-underscore-dangle: ["error", { "allowAfterThis": true }],*/
+    no-underscore-dangle: 0,
+    no-buffer-constructor: 0,
+    spaced-comment: ["error", "always", { "exceptions": ["/"] }],
+    prefer-object-spread: 0,
+    operator-linebreak: ["error", "after"]
+  },
+  "env": {
+    /* "mocha": true */
+    /* "node": true */
+  }
+}
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
     "smart-buffer": "^4.1.0"
   },
   "devDependencies": {
+    "eslint": "^5.16.0",
+    "eslint-config-airbnb": "^18.0.1",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-react": "^7.14.3",
+    "eslint-plugin-react-hooks": "^1.7.0",
     "getopts": "*"
   },
   "contributors": [


### PR DESCRIPTION
* Adds eslint with a default config for linting
* This uses the eslint extension for VSCode here: https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint
It should just work in VSCode with that extension. You'll need to run a new npm install of course.

You can modify the config in **.eslintrc**.

You can autofix the index.js with eslint according to your config like this:
`./node_modules/.bin/eslint --fix index.js`

It is biased towards node and es2015 I believe, so it will prefer `const` over var and other things. Each linting rule, if you hover over, gives you a rule that you can google for that will give a description of why it's suggested

lastly, you can turn off rules inline with
`offending code // eslint-disable-line`
or
`// eslint-disable-next-line`
`offending code`

@markabrahams optional if you want to take this. Feel free to decline if you don't want it. But it might be helpful!