### PR TITLE
Add eslint configuration and fix lint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,76 @@
+{
+  "extends": "eslint:recommended",
+  "env": {
+    "es6": true,
+    "node": true,
+    "browser": true,
+    "mocha": true
+  },
+  "parserOptions": {
+      "ecmaVersion": 2016
+  },
+  "globals": {
+    "window": false,
+    "document": false,
+    "$": false,
+    "System": false,
+    "expect": false
+  },
+  "rules": {
+    "accessor-pairs": "error",
+    "arrow-spacing": "error",
+    "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+    "camelcase": [ "error", { "properties": "never" } ],
+    "comma-spacing": ["error", { "before": false, "after": true }],
+    // "curly": [ "error", "all" ],
+    // "dot-notation": "error",
+    "eol-last": ["error", "always"],
+    // "eqeqeq": ["error", "always"],
+    // "indent": ["error", "tab", { "MemberExpression": "off", "SwitchCase": 1, "ObjectExpression": "first" } ],
+    "key-spacing": [ "error", { "beforeColon": false, "afterColon": true, "mode": "minimum" } ],
+    "keyword-spacing": [ "error", {} ],
+    "no-cond-assign": "error",
+    "no-console": ["off", { "allow": ["warn", "error"] }],
+    "no-constant-condition": ["error", { "checkLoops": false }],
+    "no-eval": "error",
+    "no-fallthrough": "off",
+    "no-mixed-spaces-and-tabs": "error",
+    // "no-multiple-empty-lines": "error",
+    "no-restricted-globals": ["error", "event"],
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "*:not(ExpressionStatement) > CallExpression[callee.property.name='sort']:not([callee.object.type='CallExpression']):not([callee.object.type='ArrayExpression']):not([callee.object.name='mongoUtil'])",
+        "message": "Restricted Array Mutation: Use `array.slice().sort(...)` if mutation was not intended, otherwise place on own line."
+      },
+      {
+        "selector": "*:not(ExpressionStatement) > CallExpression[callee.property.name='reverse']:not([callee.object.type='CallExpression']):not([callee.object.type='ArrayExpression'])",
+        "message": "Restricted Array Mutation: Use `array.slice().reverse(...)` if mutation was not intended, otherwise place on own line."
+      },
+      {
+        "selector": "*:not(ExpressionStatement) > CallExpression[callee.property.name='push']",
+        "message": "Restricted Array Mutation: `array.push(...)` returns push count, not array reference, place statement on own line."
+      }
+    ],
+    // "no-return-assign": "error",
+    // "no-trailing-spaces": "error",
+    "no-undef": "error",
+    "no-unused-expressions": "error",
+    "no-unused-vars": ["error", { "vars": "all", "args": "none" }],
+    // "no-use-before-define": [ "error", { "functions": false } ],
+    "no-useless-escape": "off",
+    "no-with": "error",
+    "padding-line-between-statements": [
+      "error",
+      { "blankLine": "always", "prev": "*", "next": "function" }
+    ],
+    // "quotes": [ "error", "double", { "allowTemplateLiterals": true, "avoidEscape": true } ],
+    "semi": [ "error", "always" ],
+    "space-before-blocks": [ "error", "always" ],
+    // "space-before-function-paren": [ "error", { "anonymous": "always", "named": "always", "asyncArrow": "always" } ],
+    // "space-in-parens": [ "error", "never" ],
+    // "space-infix-ops": "error",
+    // "space-unary-ops": [ "error", { "nonwords": true, "overrides": {} } ],
+    // "spaced-comment": [ "error", "always", {"block": {"exceptions": ["*", "!"], "balanced": true}} ]
+  }
+}

--- a/example/cisco-device-inventory.js
+++ b/example/cisco-device-inventory.js
@@ -52,7 +52,7 @@ function pollDeviceDevices (session, device, pollCb) {
 				if (error) {
 					pollCb (error, null);
 				} else {
-					for (index in table) {
+					for (var index in table) {
 						var mac = new Buffer (index.split (".")).toString ("hex");
 						var row = table[index];
 						delete table[index];
@@ -108,7 +108,7 @@ function pollDeviceVlans (session, device, pollCb) {
 			device.vlandIds = [];
 			device.devices = {};
 
-			for (index in table) {
+			for (var index in table) {
 				var match = index.match (/(\d+)$/);
 				if (match) {
 					var vlanId = match[1];

--- a/example/mib-parser.js
+++ b/example/mib-parser.js
@@ -42,7 +42,7 @@ mib.registerProviders (providers);
 // ifNumber
 // Scalar type - setScalarValue() and getScalarValue() are the entire API for these
 mib.setScalarValue ("ifNumber", 5);
-var ifNumberValue = mib.getScalarValue ("ifNumber", 5)
+var ifNumberValue = mib.getScalarValue ("ifNumber", 5);
 // console.log (ifNumberValue);
 
 // ifEntry
@@ -81,7 +81,7 @@ var ifStackEntryCell1 = mib.getTableSingleCell ("ifStackEntry", 1, [1, 2]);
 
 // ifRcvAddressEntry
 // Composite index - one foreign integer column, one local string column
-mib.addTableRow ("ifRcvAddressEntry", [1, "24:41:8c:08:87:5c", 1, 6])
+mib.addTableRow ("ifRcvAddressEntry", [1, "24:41:8c:08:87:5c", 1, 6]);
 var ifRcvAddressEntryRow1 = mib.getTableRowCells ("ifRcvAddressEntry", [1, "24:41:8c:08:87:5c"]);
 var ifRcvAddressEntryCell1 = mib.getTableSingleCell ("ifRcvAddressEntry", 3, [1, "24:41:8c:08:87:5c"]);
 var ifRcvAddressEntryData1 = mib.getTableCells ("ifRcvAddressEntry", false, false);

--- a/example/mib-parser.js
+++ b/example/mib-parser.js
@@ -111,9 +111,9 @@ mib.addTableRow ("sysOREntry", [1, "1.3.6.1.4.1.47491.42.43.44.45", "I've dreame
 
 // mib.dump ();
 
-modules = store.getModules (true);
-one = store.getModule ("SNMPv2-MIB");
-names = store.getModuleNames (true);
+var modules = store.getModules (true);
+var one = store.getModule ("SNMPv2-MIB");
+var names = store.getModuleNames (true);
 
 // console.log("All modules: ", JSON.stringify(modules, '', 2));
 console.log("Modules: ", names);

--- a/example/mib-parser.js
+++ b/example/mib-parser.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unused-vars */
+
 var snmp = require ("../");
 var getopts = require ("getopts");
 

--- a/example/option-parser.js
+++ b/example/option-parser.js
@@ -67,8 +67,8 @@ if ( command.includes('snmp-set') ) {
     }
 } else {
     oids = [];
-    for (var i = 1; i < options._.length; i++) {
-        oids.push (options._[i]);
+    for (var j = 1; j < options._.length; j++) {
+        oids.push (options._[j]);
     }
 }
 if ( command.includes('snmp-trap') || command.includes('snmp-inform') || command.includes('snmp-receiver') ) {

--- a/example/option-parser.js
+++ b/example/option-parser.js
@@ -18,7 +18,7 @@ if ( ! options.v ) {
 
 snmpOptions.version = snmp.Version[options.v];
 snmpOptions.debug = options.d;
-snmpOptions.transport = options.t
+snmpOptions.transport = options.t;
 if ( snmpOptions.version == snmp.Version3 ) {
     var engineID;
     if ( options.e ) {
@@ -72,9 +72,9 @@ if ( command.includes('snmp-set') ) {
     }
 }
 if ( command.includes('snmp-trap') || command.includes('snmp-inform') || command.includes('snmp-receiver') ) {
-    snmpOptions.trapPort = options.p
+    snmpOptions.trapPort = options.p;
 } else {
-    snmpOptions.port = options.p
+    snmpOptions.port = options.p;
 }
 
 if ( snmpOptions.version == snmp.Version3 ) {

--- a/example/receiver-lcd.js
+++ b/example/receiver-lcd.js
@@ -5,7 +5,7 @@ var snmp = require ("../");
 
 var cb = function(error, trap) {
     console.log ("Ignoring notifications");
-}
+};
 
 var receiver = snmp.createReceiver ({}, cb);
 var authorizer = receiver.getAuthorizer ();
@@ -22,10 +22,10 @@ console.log ("Fetch existing 'public' community:");
 console.log (authorizer.getCommunity("public"));
 console.log ("Fetch non-existent community 'notfound':");
 console.log (authorizer.getCommunity("notfound"));
-console.log ("Delete non-existent community 'notfound':")
+console.log ("Delete non-existent community 'notfound':");
 authorizer.deleteCommunity("notfound");
 console.log ("communities =", authorizer.getCommunities () );
-console.log ("Delete existing community 'private':")
+console.log ("Delete existing community 'private':");
 authorizer.deleteCommunity("private");
 console.log ("communities =", authorizer.getCommunities () );
 
@@ -62,10 +62,10 @@ console.log (authorizer.getUser("barney"));
 console.log ("Add existing user 'wilma' (should replace existing 'wilma'):");
 authorizer.addUser (newWilma);
 console.log ("users =", authorizer.getUsers () );
-console.log ("Delete non-existent user 'barney':")
+console.log ("Delete non-existent user 'barney':");
 authorizer.deleteUser("barney");
 console.log ("users =", authorizer.getUsers () );
-console.log ("Delete existing user 'wilma':")
+console.log ("Delete existing user 'wilma':");
 authorizer.deleteUser("wilma");
 console.log ("users =", authorizer.getUsers () );
 

--- a/example/snmp-get-bulk.js
+++ b/example/snmp-get-bulk.js
@@ -26,12 +26,12 @@ session.getBulk (oids, nonRepeaters, maxRepetitions, function (error,
 		}
 		
 		// then step through the repeaters which are varbind arrays
-		for (var i = nonRepeaters; i < varbinds.length; i++) {
-			for (var j = 0; j < varbinds[i].length; j++) {
-				if (snmp.isVarbindError (varbinds[i][j]))
-					console.error (snmp.varbindError (varbinds[i][j]));
+		for (var j = nonRepeaters; j < varbinds.length; j++) {
+			for (var k = 0; k < varbinds[j].length; k++) {
+				if (snmp.isVarbindError (varbinds[j][k]))
+					console.error (snmp.varbindError (varbinds[j][k]));
 				else
-					console.log (varbinds[i][j].oid + "|" + varbinds[i][j].value);
+					console.log (varbinds[j][k].oid + "|" + varbinds[j][k].value);
 			}
 		}
 	}

--- a/example/snmp-receiver.js
+++ b/example/snmp-receiver.js
@@ -27,7 +27,7 @@ var cb = function(error, trap) {
             }
         }
     }
-}
+};
 
 var receiver = snmp.createReceiver(snmpOptions, cb);
 var authorizer = receiver.getAuthorizer ();

--- a/example/snmp-set.js
+++ b/example/snmp-set.js
@@ -1,7 +1,6 @@
 
 // Copyright 2013 Stephen Vickers
 
-var snmp = require ("../");
 var options = require("./option-parser");
 
 var session = options.session;

--- a/example/snmp-table-columns.js
+++ b/example/snmp-table-columns.js
@@ -1,7 +1,6 @@
 
 // Copyright 2013 Stephen Vickers
 
-var snmp = require ("../");
 var options = require("./option-parser");
 
 var session = options.session;

--- a/example/snmp-table-columns.js
+++ b/example/snmp-table-columns.js
@@ -23,13 +23,13 @@ function responseCb (error, table) {
 		console.error (error.toString ());
 	} else {
 		var indexes = [];
-		for (index in table)
+		for (var index in table)
 			indexes.push (index);
 		indexes.sort ();
 
 		for (var i = 0; i < indexes.length; i++) {
 			var columns = [];
-			for (column in table[indexes[i]])
+			for (var column in table[indexes[i]])
 				columns.push (parseInt (column));
 			columns.sort (sortInt);
 

--- a/example/snmp-table.js
+++ b/example/snmp-table.js
@@ -22,13 +22,13 @@ function responseCb (error, table) {
 		console.error (error.toString ());
 	} else {
 		var indexes = [];
-		for (index in table)
+		for (var index in table)
 			indexes.push (index);
 		indexes.sort ();
 
 		for (var i = 0; i < indexes.length; i++) {
 			var columns = [];
-			for (column in table[indexes[i]])
+			for (var column in table[indexes[i]])
 				columns.push (parseInt (column));
 			columns.sort (sortInt);
 

--- a/example/snmp-table.js
+++ b/example/snmp-table.js
@@ -1,7 +1,6 @@
 
 // Copyright 2013 Stephen Vickers
 
-var snmp = require ("../");
 var options = require("./option-parser");
 
 var session = options.session;

--- a/index.js
+++ b/index.js
@@ -5070,11 +5070,11 @@ Subagent.prototype.getBulkRequest = function (pdu) {
 	}
 
 	while ( getBulkVarbinds.length < pdu.maxRepetitions && ! endOfMib ) {
-		for (var v = pdu.nonRepeaters ; v < pdu.searchRangeList.length ; v++ ) {
+		for (var w = pdu.nonRepeaters ; w < pdu.searchRangeList.length ; w++ ) {
 			if (getBulkVarbinds.length < pdu.maxRepetitions ) {
-				getNextNode = this.addGetNextVarbind (getBulkVarbinds, startOid[v - pdu.nonRepeaters]);
+				getNextNode = this.addGetNextVarbind (getBulkVarbinds, startOid[w - pdu.nonRepeaters]);
 				if ( getNextNode ) {
-					startOid[v - pdu.nonRepeaters] = getNextNode.oid;
+					startOid[w - pdu.nonRepeaters] = getNextNode.oid;
 					if ( getNextNode.type == ObjectType.EndOfMibView ) {
 						endOfMib = true;
 					}

--- a/index.js
+++ b/index.js
@@ -336,7 +336,7 @@ function readUint (buffer, isSigned) {
 	var signedBitSet = false;
 
 	if (length > 5) {
-		 throw new RangeError ("Integer too long '" + length + "'");
+		throw new RangeError ("Integer too long '" + length + "'");
 	} else if (length == 5) {
 		if (buffer.readByte () !== 0)
 			throw new RangeError ("Integer too long '" + length + "'");
@@ -1266,7 +1266,7 @@ Message.prototype.toBufferV3 = function () {
 	} else if ( this.msgSecurityParameters.msgPrivacyParameters.length > 0 ) {
 		msgSecurityParametersWriter.writeBuffer (this.msgSecurityParameters.msgPrivacyParameters, ber.OctetString);
 	} else {
-		 msgSecurityParametersWriter.writeString ("");
+		msgSecurityParametersWriter.writeString ("");
 	}
 	msgSecurityParametersWriter.endSequence ();
 
@@ -3834,34 +3834,34 @@ Mib.convertOidToAddress = function (oid) {
 
 		if (address[i] === true || address[i] === false) {
 			throw new TypeError('object identifier component ' +
-			    address[i] + ' is malformed');
+				address[i] + ' is malformed');
 		}
 
 		n = Number(address[i]);
 
 		if (isNaN(n)) {
 			throw new TypeError('object identifier component ' +
-			    address[i] + ' is malformed');
+				address[i] + ' is malformed');
 		}
 		if (n % 1 !== 0) {
 			throw new TypeError('object identifier component ' +
-			    address[i] + ' is not an integer');
+				address[i] + ' is not an integer');
 		}
 		if (i === 0 && n > 2) {
 			throw new RangeError('object identifier does not ' +
-			    'begin with 0, 1, or 2');
+				'begin with 0, 1, or 2');
 		}
 		if (i === 1 && n > 39) {
 			throw new RangeError('object identifier second ' +
-			    'component ' + n + ' exceeds encoding limit of 39');
+				'component ' + n + ' exceeds encoding limit of 39');
 		}
 		if (n < 0) {
 			throw new RangeError('object identifier component ' +
-			    address[i] + ' is negative');
+				address[i] + ' is negative');
 		}
 		if (n > MAX_INT32) {
 			throw new RangeError('object identifier component ' +
-			    address[i] + ' is too large');
+				address[i] + ' is too large');
 		}
 		oidArray.push(n);
 	}

--- a/index.js
+++ b/index.js
@@ -541,7 +541,7 @@ SimplePdu.prototype.initializeFromVariables = function (id, varbinds, options) {
 	this.varbinds = varbinds;
 	this.options = options || {};
 	this.contextName = (options && options.context) ? options.context : "";
-}
+};
 
 SimplePdu.prototype.initializeFromBuffer = function (reader) {
 	this.type = reader.peek ();
@@ -672,7 +672,7 @@ TrapPdu.createFromBuffer = function (reader) {
 	pdu.agentAddr = readIpAddress (reader);
 	pdu.generic = reader.readInt ();
 	pdu.specific = reader.readInt ();
-	pdu.upTime = readUint (reader)
+	pdu.upTime = readUint (reader);
 
 	pdu.varbinds = [];
 	readVarbinds (reader, pdu.varbinds);
@@ -1110,7 +1110,7 @@ Encryption.generateIvAes = function (aes, engineBoots, engineTime, salt) {
 	salt.copy (iv, 8, 0, 8);
 
 	return iv;
-}
+};
 
 Encryption.encryptPduAes = function (scopedPdu, privPassword, authProtocol, engine) {
 	var aes = Encryption.algorithms[PrivProtocols.aes];
@@ -1181,7 +1181,7 @@ Encryption.algorithms[PrivProtocols.aes] = {
  **/
 
 var Message = function () {
-}
+};
 
 Message.prototype.getReqId = function () {
 	return this.version == Version3 ? this.msgGlobalData.msgID : this.pdu.id;
@@ -1193,7 +1193,7 @@ Message.prototype.toBuffer = function () {
 	} else {
 		return this.toBufferCommunity();
 	}
-}
+};
 
 Message.prototype.toBufferCommunity = function () {
 	if (this.buffer)
@@ -1387,7 +1387,7 @@ Message.prototype.setMsgFlags = function (bitPosition, flag) {
 			this.msgGlobalData.msgFlags = this.msgGlobalData.msgFlags & ( 255 - 2 ** bitPosition );
 		}
 	}
-}
+};
 
 Message.prototype.hasAuthentication = function () {
 	return this.msgGlobalData && this.msgGlobalData.msgFlags && this.msgGlobalData.msgFlags & 1;
@@ -1533,7 +1533,7 @@ Message.createDiscoveryV3 = function (pdu) {
 		level: SecurityLevel.noAuthNoPriv
 	};
 	return Message.createRequestV3 (emptyUser, msgSecurityParameters, pdu);
-}
+};
 
 Message.createFromBuffer = function (buffer, user) {
 	var reader = new ber.Reader (buffer);
@@ -2560,7 +2560,7 @@ Session.prototype.sendV3Discovery = function (originalPdu, feedCb, responseCb, o
 	discoveryReq.originalPdu = originalPdu;
 	discoveryReq.allowReport = true;
 	this.send (discoveryReq);
-}
+};
 
 Session.prototype.userSecurityModelError = function (req, oid) {
 	var oidSuffix = oid.replace (UsmStatsBase + '.', '').replace (/\.0$/, '');
@@ -2633,7 +2633,7 @@ Engine.prototype.generateEngineID = function() {
 	this.engineID = Buffer.alloc (17);
 	this.engineID.fill ('8000B98380', 'hex', 0, 5);
 	this.engineID.fill (crypto.randomBytes (12), 5, 17, 'hex');
-}
+};
 
 var Listener = function (options, receiver) {
 	this.receiver = receiver;
@@ -2728,7 +2728,7 @@ var Authorizer = function (disableAuthorization) {
 	this.communities = [];
 	this.users = [];
 	this.disableAuthorization = disableAuthorization;
-}
+};
 
 Authorizer.prototype.addCommunity = function (community) {
 	if ( this.getCommunity (community) ) {
@@ -2827,7 +2827,7 @@ Receiver.prototype.onMsg = function (buffer, rinfo) {
 		var reportMessage = message.createReportResponseMessage (this.engine, this.context);
 		this.listener.send (reportMessage, rinfo);
 		return;
-	};
+	}
 
 	// Inform/trap processing
 	debug (JSON.stringify (message.pdu, null, 2));
@@ -2843,7 +2843,7 @@ Receiver.prototype.onMsg = function (buffer, rinfo) {
 	} else {
 		this.callback (new RequestInvalidError ("Unexpected PDU type " + message.pdu.type + " (" + PduType[message.pdu.type] + ")"));
 	}
-}
+};
 
 Receiver.prototype.formatCallbackData = function (pdu, rinfo) {
 	if ( pdu.contextEngineID ) {
@@ -2961,7 +2961,7 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 					if ( ! mibEntry ) {
 						break;
 					}
-					syntax = mibEntry.SYNTAX
+					syntax = mibEntry.SYNTAX;
 
 					if ( typeof syntax == "object" ) {
 						syntax = "INTEGER";
@@ -3061,7 +3061,7 @@ ModuleStore.BASE_MODULES = [
 
 var MibNode = function(address, parent) {
 	this.address = address;
-	this.oid = this.address.join('.');;
+	this.oid = this.address.join('.');
 	this.parent = parent;
 	this.children = {};
 };
@@ -3228,7 +3228,7 @@ MibNode.prototype.delete = function () {
 
 MibNode.prototype.pruneUpwards = function () {
 	if ( ! this.parent ) {
-		return
+		return;
 	}
 	if ( Object.keys (this.children).length == 0 ) {
 		var lastAddressPart = this.address.splice(-1)[0].toString();
@@ -3236,7 +3236,7 @@ MibNode.prototype.pruneUpwards = function () {
 		this.parent.pruneUpwards();
 		this.parent = null;
 	}
-}
+};
 
 MibNode.prototype.dump = function (options) {
 	var valueString;
@@ -3317,7 +3317,7 @@ Mib.prototype.lookupAddress = function (address) {
 	node = this.root;
 	for (i = 0; i < address.length; i++) {
 		if ( ! node.children.hasOwnProperty (address[i])) {
-			return null
+			return null;
 		}
 		node = node.children[address[i]];
 	}
@@ -3344,7 +3344,7 @@ Mib.prototype.getTreeNode = function (oid) {
 	}
 	return this.root;
 
-}
+};
 
 Mib.prototype.getProviderNodeForInstance = function (instanceNode) {
 	if ( instanceNode.provider ) {
@@ -3872,7 +3872,7 @@ Mib.convertOidToAddress = function (oid) {
 
 Mib.getSubOidFromBaseOid = function (oid, base) {
 	return oid.substring (base.length + 1);
-}
+};
 
 Mib.create = function () {
 	return new Mib (); 
@@ -4075,7 +4075,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 		} else {
 			mibRequests[i].done ();
 		}
-	};
+	}
 };
 
 Agent.prototype.getRequest = function (requestMessage, rinfo) {
@@ -4275,7 +4275,7 @@ Forwarder.prototype.dumpProxies = function () {
 			target: proxy.target,
 			user: proxy.user,
 			port: proxy.port
-		}
+		};
 	}
 	console.log (JSON.stringify (dump, null, 2));
 };
@@ -4984,7 +4984,7 @@ Subagent.prototype.request = function (pdu, requestVarbinds) {
 		} else {
 			mibRequest.done ();
 		}
-	};
+	}
 };
 
 Subagent.prototype.addGetNextVarbind = function (targetVarbinds, startOid) {

--- a/index.js
+++ b/index.js
@@ -2516,7 +2516,7 @@ function walkCb (req, error, varbinds) {
 Session.prototype.walk  = function () {
 	var me = this;
 	var oid = arguments[0];
-	var maxRepetitions, feedCb, doneCb, baseOid;
+	var maxRepetitions, feedCb, doneCb;
 
 	if (arguments.length < 4) {
 		maxRepetitions = 20;
@@ -2652,7 +2652,7 @@ Listener.prototype.startListening = function () {
 };
 
 Listener.prototype.send = function (message, rinfo) {
-	var me = this;
+	// var me = this;
 	
 	var buffer = message.toBuffer ();
 

--- a/index.js
+++ b/index.js
@@ -1371,7 +1371,7 @@ Message.prototype.checkAuthentication = function (user, responseCb) {
 		responseCb (new ResponseInvalidError ("Authentication digest "
 				+ this.msgSecurityParameters.msgAuthenticationParameters.toString ('hex')
 				+ " received in message does not match digest "
-				+ Authentication.calculateDigest (buffer, user.authProtocol, user.authKey,
+				+ Authentication.calculateDigest (this.buffer, user.authProtocol, user.authKey,
 					this.msgSecurityParameters.msgAuthoritativeEngineID).toString ('hex')
 				+ " calculated for message") );
 		return false;
@@ -2385,7 +2385,7 @@ Session.prototype.trap = function () {
 			options = arguments[1];
 		} else {
 			varbinds = arguments[1];
-			agentAddr = null;
+			options.agentAddr = null;
 		}
 		responseCb = arguments[2];
 	} else {
@@ -3378,7 +3378,7 @@ Mib.prototype.getColumnFromProvider = function (provider, indexEntry) {
 	return column;
 };
 
-Mib.prototype.populateIndexEntryFromColumn = function (localProvider, indexEntry) {
+Mib.prototype.populateIndexEntryFromColumn = function (localProvider, indexEntry, i) {
 	var column = null;
 	var tableProviders;
 	if ( ! indexEntry.columnName && ! indexEntry.columnNumber ) {
@@ -3407,11 +3407,11 @@ Mib.prototype.populateIndexEntryFromColumn = function (localProvider, indexEntry
 		throw new Error ("Could not find column for index entry with column " + indexEntry.columnName);
 	}
 	if ( indexEntry.columnName && indexEntry.columnName != column.name ) {
-		throw new Error ("Index entry " + i + ": Calculated column name " + calculatedColumnName +
+		throw new Error ("Index entry " + i + ": Calculated column name " + column.name +
 				"does not match supplied column name " + indexEntry.columnName);
 	}
 	if ( indexEntry.columnNumber && indexEntry.columnNumber != column.number ) {
-		throw new Error ("Index entry " + i + ": Calculated column number " + calculatedColumnNumber +
+		throw new Error ("Index entry " + i + ": Calculated column number " + column.number +
 				" does not match supplied column number " + indexEntry.columnNumber);
 	}
 	if ( ! indexEntry.columnName ) {
@@ -3453,7 +3453,7 @@ Mib.prototype.registerProvider = function (provider) {
 					};
 				}
 				indexEntry = provider.tableIndex[i];
-				this.populateIndexEntryFromColumn (provider, indexEntry);
+				this.populateIndexEntryFromColumn (provider, indexEntry, i);
 			}
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -2824,7 +2824,7 @@ Receiver.prototype.onMsg = function (buffer, rinfo) {
 			this.callback (new RequestInvalidError ("Only discovery GetRequests are supported and this message does not have the reportable flag set"));
 			return;
 		}
-		var reportMessage = message.createReportResponseMessage (this.engine, this.context);
+		reportMessage = message.createReportResponseMessage (this.engine, this.context);
 		this.listener.send (reportMessage, rinfo);
 		return;
 	}
@@ -2938,7 +2938,7 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 	syntaxTypes = this.getSyntaxTypes ();
 	entryArray = Object.values (mibModule);
 	for ( var i = 0; i < entryArray.length ; i++ ) {
-		var mibEntry = entryArray[i];
+		mibEntry = entryArray[i];
 		var syntax = mibEntry.SYNTAX;
 
 		if ( syntax ) {
@@ -3288,7 +3288,6 @@ Mib.prototype.addNodesForOid = function (oidString) {
 };
 
 Mib.prototype.addNodesForAddress = function (address) {
-	var address;
 	var node;
 	var i;
 
@@ -4159,11 +4158,11 @@ Agent.prototype.getBulkRequest = function (requestMessage, rinfo) {
 	}
 
 	while ( getBulkVarbinds.length < requestPdu.maxRepetitions && ! endOfMib ) {
-		for (var v = requestPdu.nonRepeaters ; v < requestVarbinds.length ; v++ ) {
+		for (var w = requestPdu.nonRepeaters ; w < requestVarbinds.length ; w++ ) {
 			if (getBulkVarbinds.length < requestPdu.maxRepetitions ) {
-				getNextNode = this.addGetNextVarbind (getBulkVarbinds, startOid[v - requestPdu.nonRepeaters]);
+				getNextNode = this.addGetNextVarbind (getBulkVarbinds, startOid[w - requestPdu.nonRepeaters]);
 				if ( getNextNode ) {
-					startOid[v - requestPdu.nonRepeaters] = getNextNode.oid;
+					startOid[w - requestPdu.nonRepeaters] = getNextNode.oid;
 					if ( getNextNode.type == ObjectType.EndOfMibView ) {
 						endOfMib = true;
 					}

--- a/index.js
+++ b/index.js
@@ -2878,7 +2878,7 @@ ModuleStore.prototype.getSyntaxTypes = function () {
 
 	for ( var mibModule of Object.values (this.parser.Modules) ) {
 		entryArray = Object.values (mibModule);
-		for ( mibEntry of entryArray ) {
+		for ( var mibEntry of entryArray ) {
 			if ( mibEntry.MACRO == "TEXTUAL-CONVENTION" ) {
 				if ( mibEntry.SYNTAX && ! syntaxTypes[mibEntry.ObjectName] ) {
 					if ( typeof mibEntry.SYNTAX == "object" ) {
@@ -3096,7 +3096,7 @@ MibNode.prototype.findChildImmediatelyBefore = function (index) {
 		return null;
 	}
 
-	for ( i = 0; i < sortedChildrenKeys.length; i++ ) {
+	for ( var i = 0; i < sortedChildrenKeys.length; i++ ) {
 		if ( index < sortedChildrenKeys[i] ) {
 			if ( i === 0 ) {
 				return null;
@@ -3182,6 +3182,7 @@ MibNode.prototype.getInstanceNodesForColumn = function () {
 
 MibNode.prototype.getNextInstanceNode = function () {
 	var siblingIndex;
+	var childrenAddresses;
 
 	var node = this;
 	if ( this.value != null ) {
@@ -3195,7 +3196,7 @@ MibNode.prototype.getNextInstanceNode = function () {
 				return null;
 			} else {
 				childrenAddresses = Object.keys (node.children).sort ( (a, b) => a - b);
-				siblingPosition = childrenAddresses.indexOf(siblingIndex.toString());
+				var siblingPosition = childrenAddresses.indexOf(siblingIndex.toString());
 				if ( siblingPosition + 1 < childrenAddresses.length ) {
 					node = node.children[childrenAddresses[siblingPosition + 1]];
 					break;
@@ -3221,7 +3222,7 @@ MibNode.prototype.delete = function () {
 	if ( Object.keys (this.children) > 0 ) {
 		throw new Error ("Cannot delete non-leaf MIB node");
 	}
-	addressLastPart = this.address.slice(-1)[0];
+	var addressLastPart = this.address.slice(-1)[0];
 	delete this.parent.children[addressLastPart];
 	this.parent = null;
 };
@@ -3252,7 +3253,7 @@ MibNode.prototype.dump = function (options) {
 		}
 		console.log (this.oid + valueString);
 	}
-	for ( node of Object.keys (this.children).sort ((a, b) => a - b)) {
+	for ( var node of Object.keys (this.children).sort ((a, b) => a - b)) {
 		this.children[node].dump (options);
 	}
 };
@@ -3336,8 +3337,8 @@ Mib.prototype.getTreeNode = function (oid) {
 	}
 
 	while ( address.length > 0 ) {
-		last = address.pop ();
-		parent = this.lookupAddress (address);
+		var last = address.pop ();
+		var parent = this.lookupAddress (address);
 		if ( parent ) {
 			return (parent.findChildImmediatelyBefore (last) || parent);
 		}
@@ -3430,7 +3431,7 @@ Mib.prototype.registerProvider = function (provider) {
 			if ( provider.tableAugments == provider.name ) {
 				throw new Error ("Table " + provider.name + " cannot augment itself");
 			}
-			augmentProvider = this.providers[provider.tableAugments];
+			var augmentProvider = this.providers[provider.tableAugments];
 			if ( ! augmentProvider ) {
 				throw new Error ("Cannot find base table " + provider.tableAugments + " to augment");
 			}
@@ -3467,7 +3468,7 @@ Mib.prototype.registerProviders = function (providers) {
 Mib.prototype.unregisterProvider = function (name) {
 	var providerNode = this.providerNodes[name];
 	if ( providerNode ) {
-		providerNodeParent = providerNode.parent;
+		var providerNodeParent = providerNode.parent;
 		providerNode.delete();
 		providerNodeParent.pruneUpwards();
 		delete this.providerNodes[name];
@@ -3600,7 +3601,8 @@ Mib.prototype.getRowIndexFromOid = function (oid, index) {
 	var addressRemaining = oid.split (".");
 	var length = 0;
 	var values = [];
-	for ( indexPart of index ) {
+	var value;
+	for ( var indexPart of index ) {
 		switch ( indexPart.type ) {
 			case ObjectType.OID:
 				if ( indexPart.implied ) {
@@ -3634,7 +3636,9 @@ Mib.prototype.getRowIndexFromOid = function (oid, index) {
 };
 
 Mib.prototype.getTableRowInstanceFromRowIndex = function (provider, rowIndex) {
-	rowIndexOid = [];
+	var rowIndexOid = [];
+	var indexPart;
+	var keyPart;
 	for ( var i = 0; i < provider.tableIndex.length ; i++ ) {
 		indexPart = provider.tableIndex[i];
 		keyPart = rowIndex[i];
@@ -3649,6 +3653,7 @@ Mib.prototype.addTableRow = function (table, row) {
 	var instance = [];
 	var instanceAddress;
 	var instanceNode;
+	var rowValueOffset;
 
 	if ( this.providers[table] && ! this.providerNodes[table] ) {
 		this.addProviderToNode (this.providers[table]);
@@ -3763,6 +3768,7 @@ Mib.prototype.setTableSingleCell = function (table, columnNumber, rowIndex, valu
 	var providerNode;
 	var columnNode;
 	var instanceNode;
+	var instanceAddress;
 
 	provider = this.providers[table];
 	providerNode = this.getProviderNodeForTable (table);
@@ -3778,6 +3784,7 @@ Mib.prototype.deleteTableRow = function (table, rowIndex) {
 	var instanceAddress;
 	var columnNode;
 	var instanceNode;
+	var instanceParentNode;
 
 	provider = this.providers[table];
 	providerNode = this.getProviderNodeForTable (table);
@@ -4037,6 +4044,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 		}
 
 		(function (savedIndex) {
+			var responseVarbind;
 			mibRequests[savedIndex].done = function (error) {
 				if ( error ) {
 					if ( responsePdu.errorStatus == ErrorStatus.NoError && error.errorStatus != ErrorStatus.NoError ) {
@@ -4453,6 +4461,7 @@ AgentXPdu.createFromBuffer = function (socketBuffer) {
 };
 
 AgentXPdu.writeOid = function (buffer, oid, include = 0) {
+	var prefix;
 	if ( oid ) {
 		var address = oid.split ('.').map ( Number );
 		if ( address.length >= 5 && address.slice (0, 4).join('.') == '1.3.6.1' ) {
@@ -4940,6 +4949,7 @@ Subagent.prototype.request = function (pdu, requestVarbinds) {
 		}
 
 		(function (savedIndex) {
+			var responseVarbind;
 			mibRequest.done = function (error) {
 				if ( error ) {
 					responseVarbind = {

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -363,8 +363,9 @@ var MIB = function (dir) {
                                         var c1 = r;
                                         var keychain = [];
                                         keychain.push('DESCRIPTION');
+                                        var key;
                                         for (var notation in MARCO['TYPE NOTATION']) {
-                                            var key = notation;
+                                            key = notation;
                                             //if TYPE NOTATION does not have a value
                                             if (MARCO['TYPE NOTATION'][notation] == null) {
                                                 //then look up the value from the MACRO Root
@@ -374,7 +375,7 @@ var MIB = function (dir) {
                                         }
                                         while (c1 < (i - 1)) {
                                             c1++;
-                                            var key = Symbols[c1]; //Parse TYPE NOTATION. ex: SYNTAX, ACCESS, STATUS, DESCRIPTION.....
+                                            key = Symbols[c1]; //Parse TYPE NOTATION. ex: SYNTAX, ACCESS, STATUS, DESCRIPTION.....
 
                                             //key == 'DESCRIPTION' ? console.log(keychain.indexOf(key), key, Symbols[c1 + 1]) : false;
 
@@ -507,22 +508,22 @@ var MIB = function (dir) {
                                         case 'VALUE NOTATION':
                                         case 'TYPE NOTATION':
                                             Object[Symbols[i - 1]] = {};
-                                            var r = i + 1;
-                                            while (Symbols[r + 1] != '::=' && Symbols[r + 1] != 'END') {
-                                                if (Symbols[r].indexOf('"') == 0) {
-                                                    var val = Symbols[r + 1];
-                                                    var t = r + 1;
-                                                    if (Symbols[r + 2].indexOf('(') == 0) {
-                                                        val = Symbols[r + 2];
-                                                        t = r + 2;
+                                            var j = i + 1;
+                                            while (Symbols[j + 1] != '::=' && Symbols[j + 1] != 'END') {
+                                                if (Symbols[j].indexOf('"') == 0) {
+                                                    var value = Symbols[j + 1];
+                                                    var t = j + 1;
+                                                    if (Symbols[j + 2].indexOf('(') == 0) {
+                                                        value = Symbols[j + 2];
+                                                        t = j + 2;
                                                     }
-                                                    Object[Symbols[i - 1]][Symbols[r].replace(/"/g, "")] = val;
-                                                    r = t;
+                                                    Object[Symbols[i - 1]][Symbols[j].replace(/"/g, "")] = value;
+                                                    j = t;
                                                 } else {
-                                                    Object[Symbols[i - 1]][Symbols[r]] = null;
-                                                    if (Symbols[r + 1].indexOf('(') == 0) {
-                                                        Object[Symbols[i - 1]][Symbols[r]] = Symbols[r + 1];
-                                                        r++;
+                                                    Object[Symbols[i - 1]][Symbols[j]] = null;
+                                                    if (Symbols[j + 1].indexOf('(') == 0) {
+                                                        Object[Symbols[i - 1]][Symbols[j]] = Symbols[j + 1];
+                                                        j++;
                                                     }
                                                 }
                                                 r++;

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -140,7 +140,7 @@ var MIB = function (dir) {
                 this.ParseLine(FileName, line, i);
                 i++;
             }
-            this.CharBuffer.Table[FileName]
+            this.CharBuffer.Table[FileName];
         },
         ParseLine: function (FileName, line, row) {
             line = line + "\n";
@@ -198,7 +198,7 @@ var MIB = function (dir) {
                         this.CharBuffer.Fill(FileName, row, column);
                     }
 
-                    if (char == '}') { this.CharBuffer.isOID = false; this.CharBuffer.isList = false; };
+                    if (char == '}') { this.CharBuffer.isOID = false; this.CharBuffer.isList = false; }
                     break;
                 case ',':
                     if (this.CharBuffer.isComment) {
@@ -298,7 +298,7 @@ var MIB = function (dir) {
                     }
                 }
 
-            };
+            }
             this.Compile();
         },
         Compile: function () {
@@ -350,7 +350,7 @@ var MIB = function (dir) {
                                     } else {
                                         var ObjectName = Symbols[r - 1];
                                         Object[ObjectName] = {};
-                                        Object[ObjectName]['ObjectName'] = ObjectName
+                                        Object[ObjectName]['ObjectName'] = ObjectName;
                                         Object[ObjectName]['ModuleName'] = ModuleName;
                                         Object[ObjectName]['MACRO'] = Symbols[r];
                                         //BUILD OBJECT FROM MACRO TYPE NOTATION
@@ -368,7 +368,7 @@ var MIB = function (dir) {
                                             //if TYPE NOTATION does not have a value
                                             if (MARCO['TYPE NOTATION'][notation] == null) {
                                                 //then look up the value from the MACRO Root
-                                                key = MARCO[notation]
+                                                key = MARCO[notation];
                                             }
                                             keychain.push(key);
                                         }
@@ -489,7 +489,7 @@ var MIB = function (dir) {
                                         if ( Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'] &&
                                                 Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'].length == 1 &&
                                                 Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'][0]['type'] == 'DESCRIPTION' ) {
-                                            delete Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS']
+                                            delete Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'];
                                         }
 
                                     }
@@ -530,7 +530,7 @@ var MIB = function (dir) {
                                             // Workaround for lack of INDEX and AUGMENTS in OBJECT-TYPE MACRO "TYPE NOTATION"
                                             if ( ModuleName == "SNMPv2-SMI" ) {
                                                 Object["TYPE NOTATION"].INDEX = "Index";
-                                                Object["TYPE NOTATION"].AUGMENTS = "Augments"
+                                                Object["TYPE NOTATION"].AUGMENTS = "Augments";
                                             } else if ( ModuleName == "RFC-1212" ) {
                                                 Object["TYPE NOTATION"].INDEX = "Index";
                                             }
@@ -562,7 +562,7 @@ var MIB = function (dir) {
                                 //console.log(ModuleName, 'IMPORTS');
                                 //i++;
                                 Module['IMPORTS'] = {};
-                                var tmp = i + 1
+                                var tmp = i + 1;
                                 var IMPORTS = [];
                                 while (Symbols[tmp] != ';') {
                                     if (Symbols[tmp] == 'FROM') {
@@ -617,7 +617,7 @@ var MIB = function (dir) {
                             Object[ObjectName]['SYNTAX'][SYNTAX] = {};
 
                             for (var TC = 0; TC < val.length; TC++) {
-                                Object[ObjectName]['SYNTAX'][SYNTAX][val[TC].split("(")[1].replace(")", "")] = val[TC].split("(")[0]
+                                Object[ObjectName]['SYNTAX'][SYNTAX][val[TC].split("(")[1].replace(")", "")] = val[TC].split("(")[0];
                             }
                         }
                         break;
@@ -728,7 +728,7 @@ var MIB = function (dir) {
             console.log("Compiling modules...");
             this.Serialize();
         }
-    })
+    });
 };
 
 module.exports = exports = MIB;

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -597,7 +597,6 @@ var MIB = function (dir) {
         BuildObject: function (Object, ObjectName, macro, i, Symbols) {
 
             var r = i;
-            var found = false;
             var m = Symbols.indexOf('SYNTAX', r) - r;
             var SYNTAX = Symbols[Symbols.indexOf('SYNTAX', r) + 1];
             var val = Symbols[Symbols.indexOf('SYNTAX', r) + 2];

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -336,8 +336,7 @@ var MIB = function (dir) {
                                         if (Object[Symbols[i - 2]]['OBJECT IDENTIFIER'] == '0 0') {
                                             Object[Symbols[i - 2]]['OID'] = '0.0';
                                             Object[Symbols[i - 2]]['NameSpace'] = 'null';
-                                        }
-                                        else {
+                                        } else {
                                             this.OID(Object[Symbols[i - 2]]['OBJECT IDENTIFIER'], '', Symbols[i - 2], '', function (ID, OD) {
 
                                                 Object[Symbols[i - 2]]['OID'] = ID;
@@ -477,8 +476,7 @@ var MIB = function (dir) {
                                         if (Object[Symbols[r - 1]]['OBJECT IDENTIFIER'] == '0 0') {
                                             Object[Symbols[r - 1]]['OID'] = '0.0';
                                             Object[Symbols[r - 1]]['NameSpace'] = 'null';
-                                        }
-                                        else {
+                                        } else {
                                             this.OID(Object[Symbols[r - 1]]['OBJECT IDENTIFIER'], '', Symbols[r - 1], '', function (ID, OD) {
 
                                                 Object[Symbols[r - 1]]['OID'] = ID;

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "smart-buffer": "^4.1.0"
   },
   "devDependencies": {
+    "eslint": "^5.16.0",
     "getopts": "*"
   },
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "monitoring"
   ],
   "author": "Mark Abrahams <mark@abrahams.co.nz>",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint . ./**/*.js"
+  }
 }

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 
 var ber    = require ('asn1-ber').Ber;
 var assert = require('assert');

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -10,7 +10,7 @@ describe('parseInt()', function() {
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a negative integer', function() {
 			assert.equal(-3, snmp.ObjectParser.readInt(reader));
-		})
+		});
 	}),
 	describe('given a positive integer', function() {
 		var writer = new ber.Writer();
@@ -18,8 +18,8 @@ describe('parseInt()', function() {
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(3245689, snmp.ObjectParser.readInt(reader));
-		})
-	})
+		});
+	});
 });
 
 describe('parseUint()', function() {
@@ -29,7 +29,7 @@ describe('parseUint()', function() {
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(3242425, snmp.ObjectParser.readUint(reader));
-		})
+		});
 	}),
 	describe('given a negative integer', function() {
 		var writer = new ber.Writer();
@@ -37,6 +37,6 @@ describe('parseUint()', function() {
 		var reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
 			assert.equal(253, snmp.ObjectParser.readUint(reader));
-		})
-	})
+		});
+	});
 });


### PR DESCRIPTION
This was inspired by https://github.com/markabrahams/node-net-snmp/pull/115 but tunes the rules and fixes some code to eliminate almost all lint errors relative to the included config.

• Adds eslint with a simple config (with no extra dependencies apart from eslint itself) which does not raise too many errors or warnings when linting the existing codebase.

• Fixes some of the simplest errors highlighted by eslint - some are simply stylistic like mixed spaces/tabs or brace styles, and others are potential causes of bugs or indeed actual bugs such as undefined vars or the use of the wrong var name.

• Adds a script config to the package so eslint can easily be run with `npm run lint`

There are still two problems reported by the eslint config in this PR, as follows:

```
/Users/gavin/repos/node-net-snmp/index.js
  4721:8  error  'provider' is not defined  no-undef

/Users/gavin/repos/node-net-snmp/lib/mib.js
  143:13  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions

✖ 2 problems (2 errors, 0 warnings)
```

The first one looks like it is definitely a bug but I wasn't sure without further research how it should be fixed, you may be able to do it very quickly. The second looks like more of a warning I think but also worth checking.

If this PR is merged (and those remaining errors fixed) it might be a good idea to setup Travis to run lint any time a PR is opened on the repo or commits added. This would automatically highlight any future problems. Setting up Travis only takes a few minutes, I could do a PR for the travis.yml config if you are interested.
