### PR TITLE
Honor MAX-ACCESS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1813,6 +1813,7 @@ var myScalarProvider = {
     type: snmp.MibProviderType.Scalar,
     oid: "1.3.6.1.2.1.1.1",
     scalarType: snmp.ObjectType.OctetString,
+    maxAccess: snmp.MaxAccess["read-write"],
     handler: function (mibRequest) {
        // e.g. can update the MIB data before responding to the request here
        mibRequest.done ();
@@ -1847,17 +1848,20 @@ var myTableProvider = {
         {
             number: 1,
             name: "ifIndex",
-            type: snmp.ObjectType.Integer
+            type: snmp.ObjectType.Integer,
+            maxAccess: snmp.MaxAccess["not-accessible"]
         },
         {
             number: 2,
             name: "ifDescr",
-            type: snmp.ObjectType.OctetString
+            type: snmp.ObjectType.OctetString,
+            maxAccess: snmp.MaxAccess["read-only"],
         },
         {
             number: 3,
             name: "ifType",
             type: snmp.ObjectType.Integer,
+            maxAccess: snmp.MaxAccess["read-write"],
             constraints: {
                 enumeration: {
                     "1": "goodif",

--- a/README.md
+++ b/README.md
@@ -1934,6 +1934,12 @@ A provider definition has these fields:
  table, and doesn't exist in the local table's column definitions.  If the `tableIndex` field is
  absent, `tableAugments` is mandatory i.e. one of `tableIndex` and `tableAugments` needs to be
  present to define the table index.
+ * `maxAccess` *(optional)* - specifies the maximum allowed access
+level provided by this provider. The allowable values are the
+numeric values from the MaxAccess export. If a `maxAccess` value is
+specified, a `get` request to the agent will return a `noAccess`
+error if `maxAccess` is not at least "read-only" (2). `maxAccess`
+must be at least "read-write" (3) for a `set` request to suceed.
  * `handler` *(optional)* - an optional callback function, which is called before the request to the
  MIB is made.  This could update the MIB value(s) handled by this provider.  If not given,
  the values are simply returned from (or set in) the MIB without any other processing.

--- a/README.md
+++ b/README.md
@@ -1920,7 +1920,7 @@ A provider definition has these fields:
  * `scalarType`  *(mandatory for scalar types)* - only relevant to scalar provider type, this
   give the type of the variable, selected from `snmp.ObjectType`
  * `tableColumns` *(mandatory for table types)* - gives any array of column definition objects for the
- table.  Each column object must have a unique `number`, a `name` and a `type` from `snmp.ObjectType`.
+ table.  Each column object must have a unique `number`, a `name`, a `type` from `snmp.ObjectType`, and a numeric `maxAccess` from `snmp.MaxAccess`.
  A column object with type `ObjectType.Integer` can optionally contain a `constraints` object, the
  format and meaning of which is identical to that defined on a single scalar provider (see `constraints`
  below for the details on this).
@@ -1934,7 +1934,7 @@ A provider definition has these fields:
  table, and doesn't exist in the local table's column definitions.  If the `tableIndex` field is
  absent, `tableAugments` is mandatory i.e. one of `tableIndex` and `tableAugments` needs to be
  present to define the table index.
- * `maxAccess` *(optional)* - specifies the maximum allowed access
+ * `maxAccess` *(mandatory)* - specifies the maximum allowed access
 level provided by this provider. The allowable values are the
 numeric values from the MaxAccess export. If a `maxAccess` value is
 specified, a `get` request to the agent will return a `noAccess`

--- a/index.js
+++ b/index.js
@@ -3784,7 +3784,6 @@ Mib.prototype.setScalarValue = function (scalarName, newValue) {
 		instanceNode.valueType = provider.scalarType;
 	}
 	instanceNode.value = newValue;
-    this.emit("setScalarValue", instanceNode, provider);
 	// return instanceNode.setValue (newValue);
 };
 
@@ -3927,7 +3926,6 @@ Mib.prototype.addTableRow = function (table, row) {
 		instanceNode = this.lookup (instanceAddress);
 		instanceNode.valueType = column.type;
 		instanceNode.value = row[rowValueOffset + i];
-        this.emit("addTableRow", instanceNode, provider);
 	}
 };
 
@@ -4035,7 +4033,6 @@ Mib.prototype.setTableSingleCell = function (table, columnNumber, rowIndex, valu
 	columnNode = providerNode.children[columnNumber];
 	instanceNode = columnNode.getInstanceNodeForTableRowIndex (instanceAddress);
 	instanceNode.value = value;
-    this.emit("setTableSingleCell", instanceNode, providerNode.provider);
 	// return instanceNode.setValue (value);
 };
 
@@ -4360,7 +4357,6 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 				} else {
 					if ( requestPdu.type == PduType.SetRequest ) {
 						mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
-                        mib.emit("agentSetValue", instanceNode, providerNode.provider);
 					}
 					if ( ( requestPdu.type == PduType.GetNextRequest || requestPdu.type == PduType.GetBulkRequest ) &&
 							requestPdu.varbinds[savedIndex].type == ObjectType.EndOfMibView ) {

--- a/index.js
+++ b/index.js
@@ -3910,7 +3910,7 @@ Mib.prototype.addTableRow = function (table, row) {
 		instanceNode = this.lookup (instanceAddress);
 		instanceNode.valueType = column.type;
 		instanceNode.value = row[rowValueOffset + i];
-        this.emit("addTableRow", instanceNode);
+        this.emit("addTableRow", instanceNode, provider);
 	}
 };
 
@@ -4018,7 +4018,7 @@ Mib.prototype.setTableSingleCell = function (table, columnNumber, rowIndex, valu
 	columnNode = providerNode.children[columnNumber];
 	instanceNode = columnNode.getInstanceNodeForTableRowIndex (instanceAddress);
 	instanceNode.value = value;
-    this.emit("setTableSingleCell", instanceNode);
+    this.emit("setTableSingleCell", instanceNode, providerNode.provider);
 	// return instanceNode.setValue (value);
 };
 
@@ -4312,7 +4312,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 				} else {
 					if ( requestPdu.type == PduType.SetRequest ) {
 						mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
-                        mib.emit("agentSetValue", instanceNode);
+                        mib.emit("agentSetValue", instanceNode, providerNode.provider);
 					}
 					if ( ( requestPdu.type == PduType.GetNextRequest || requestPdu.type == PduType.GetBulkRequest ) &&
 							requestPdu.varbinds[savedIndex].type == ObjectType.EndOfMibView ) {

--- a/index.js
+++ b/index.js
@@ -4248,7 +4248,7 @@ Agent.prototype.onMsg = function (buffer, rinfo) {
 };
 
 Agent.prototype.isAllowed = function (pduType, providerMaxAccess, provider) {
-	switch( PduType[pduType] ) {
+	switch ( PduType[pduType] ) {
 		case "SetRequest":
 			// SetRequest requires at least read-write access
 			return providerMaxAccess >= MaxAccess["read-write"];
@@ -4260,14 +4260,13 @@ Agent.prototype.isAllowed = function (pduType, providerMaxAccess, provider) {
 			return providerMaxAccess >= MaxAccess["read-only"];
 
 		default:
-		  // Disallow other pdu types (TODO: verify no others needed)
-		  return false;
+			// Disallow other pdu types (TODO: verify no others needed)
+			return false;
 	}
 };
 
 Agent.prototype.request = function (requestMessage, rinfo) {
 	var me = this;
-	var mib = this.mib;
 	var varbindsCompleted = 0;
 	var requestPdu = requestMessage.pdu;
 	var varbindsLength = requestPdu.varbinds.length;

--- a/index.js
+++ b/index.js
@@ -2951,6 +2951,7 @@ SimpleAccessControlModel.prototype.isAccessAllowed = function (securityModel, se
 var Receiver = function (options, callback) {
 	DEBUG = options.debug;
 	this.listener = new Listener (options, this);
+console.log("Receiver: listener=", this.listener, ", options=", options);
 	this.authorizer = new Authorizer (options);
 	this.engine = new Engine (options.engineID);
 
@@ -2975,24 +2976,34 @@ Receiver.prototype.onMsg = function (buffer, rinfo) {
 	var message = Listener.processIncoming (buffer, this.authorizer, this.callback);
 	var reportMessage;
 
+console.log("loc R1");
 	if ( ! message ) {
+console.log("loc R2");
 		return;
 	}
 
 	// The only GetRequest PDUs supported are those used for SNMPv3 discovery
+console.log("loc R3");
 	if ( message.pdu.type == PduType.GetRequest ) {
+console.log("loc R4");
 		if ( message.version != Version3 ) {
+console.log("loc R5");
 			this.callback (new RequestInvalidError ("Only SNMPv3 discovery GetRequests are supported"));
 			return;
 		} else if ( message.hasAuthentication() ) {
+console.log("loc R6");
 			this.callback (new RequestInvalidError ("Only discovery (noAuthNoPriv) GetRequests are supported but this message has authentication"));
 			return;
 		} else if ( ! message.isReportable () ) {
+console.log("loc R7");
 			this.callback (new RequestInvalidError ("Only discovery GetRequests are supported and this message does not have the reportable flag set"));
 			return;
 		}
+console.log("loc R8");
 		reportMessage = message.createReportResponseMessage (this.engine, this.context);
+console.log("loc R9");
 		this.listener.send (reportMessage, rinfo);
+console.log("loc R10");
 		return;
 	}
 
@@ -3253,6 +3264,7 @@ ModuleStore.BASE_MODULES = [
 var MibNode = function(address, parent) {
 	this.address = address;
 	this.oid = this.address.join('.');
+console.log("Creating MibNode for oid=", this.oid);
 	this.parent = parent;
 	this.children = {};
 };
@@ -3518,6 +3530,8 @@ var Mib = function () {
 	this.providerNodes = {};
 };
 
+util.inherits (Mib, events.EventEmitter);
+
 Mib.prototype.addNodesForOid = function (oidString) {
 	var address = Mib.convertOidToAddress (oidString);
 	return this.addNodesForAddress (address);
@@ -3765,6 +3779,7 @@ Mib.prototype.setScalarValue = function (scalarName, newValue) {
 		instanceNode.valueType = provider.scalarType;
 	}
 	instanceNode.value = newValue;
+    this.emit("setScalarValue", instanceNode, provider);
 	// return instanceNode.setValue (newValue);
 };
 
@@ -3907,6 +3922,7 @@ Mib.prototype.addTableRow = function (table, row) {
 		instanceNode = this.lookup (instanceAddress);
 		instanceNode.valueType = column.type;
 		instanceNode.value = row[rowValueOffset + i];
+        this.emit("addTableRow", instanceNode);
 	}
 };
 
@@ -4014,6 +4030,7 @@ Mib.prototype.setTableSingleCell = function (table, columnNumber, rowIndex, valu
 	columnNode = providerNode.children[columnNumber];
 	instanceNode = columnNode.getInstanceNodeForTableRowIndex (instanceAddress);
 	instanceNode.value = value;
+    this.emit("setTableSingleCell", instanceNode);
 	// return instanceNode.setValue (value);
 };
 
@@ -4145,12 +4162,19 @@ MibRequest.prototype.isTabular = function () {
 var Agent = function (options, callback, mib) {
 	DEBUG = options.debug;
 	this.listener = new Listener (options, this);
+console.log("Agent listener=", this.listener);
 	this.engine = new Engine (options.engineID);
+console.log("Agent 1");
 	this.authorizer = new Authorizer (options);
+console.log("Agent 2");
 	this.callback = callback || function () {};
+console.log("Agent 3");
 	this.mib = mib || new Mib ();
+console.log("Agent 4");
 	this.context = "";
+console.log("Agent 5");
 	this.forwarder = new Forwarder (this.listener, this.callback);
+console.log("Agent 6");
 };
 
 Agent.prototype.getMib = function () {
@@ -4190,47 +4214,60 @@ Agent.prototype.onMsg = function (buffer, rinfo) {
 	var securityName;
 	var reportMessage;
 
+console.log("loc a");
 	if ( ! message ) {
 		return;
 	}
 
 	// SNMPv3 discovery
+console.log("loc b");
 	if ( message.version == Version3 && message.pdu.type == PduType.GetRequest &&
 			! message.hasAuthoritativeEngineID() && message.isReportable () ) {
 		reportMessage = message.createReportResponseMessage (this.engine, this.context);
 		this.listener.send (reportMessage, rinfo);
+console.log("loc c");
 		return;
 	}
 
 	// Access control check
+console.log("loc d");
 	securityName = message.version == Version3 ? message.user.name : message.community;
 	if ( this.authorizer.getAccessControlModelType () == AccessControlModelType.Simple &&
 			! this.authorizer.getAccessControlModel ().isAccessAllowed (message.version, securityName, message.pdu.type) ) {
 		this.callback (new RequestFailedError ("Access denied for " + securityName + " to PDU type " + PduType[message.pdu.type] ) );
+console.log("loc e");
 		return;
 	}
 
 	// Request processing
 	// debug (JSON.stringify (message.pdu, null, 2));
 	if ( message.pdu.contextName && message.pdu.contextName != "" ) {
+console.log("loc f");
 		this.onProxyRequest (message, rinfo);
 	} else if ( message.pdu.type == PduType.GetRequest ) {
+console.log("loc g");
 		this.getRequest (message, rinfo);
 	} else if ( message.pdu.type == PduType.SetRequest ) {
+console.log("loc h");
 		this.setRequest (message, rinfo);
 	} else if ( message.pdu.type == PduType.GetNextRequest ) {
+console.log("loc i");
 		this.getNextRequest (message, rinfo);
 	} else if ( message.pdu.type == PduType.GetBulkRequest ) {
+console.log("loc j");
 		this.getBulkRequest (message, rinfo);
 	} else {
+console.log("loc k");
 		this.callback (new RequestInvalidError ("Unexpected PDU type " +
 			message.pdu.type + " (" + PduType[message.pdu.type] + ")"));
 	}
+console.log("loc l");
 
 };
 
 Agent.prototype.request = function (requestMessage, rinfo) {
 	var me = this;
+    var mib = this.mib;
 	var varbindsCompleted = 0;
 	var requestPdu = requestMessage.pdu;
 	var varbindsLength = requestPdu.varbinds.length;
@@ -4248,6 +4285,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 			requestPdu.varbinds[i].oid = "1.3.6.1";
 		}
 
+console.log("loc 1: instanceNode=", instanceNode, "oid=", requestPdu.varbinds[i].oid);
 		if ( ! instanceNode ) {
 			mibRequests[i] = new MibRequest ({
 				operation: requestPdu.type,
@@ -4263,6 +4301,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 			};
 		} else {
 			providerNode = this.mib.getProviderNodeForInstance (instanceNode);
+console.log("loc 2: providerNode=", providerNode);
 			if ( ! providerNode ) {
 				mibRequests[i] = new MibRequest ({
 					operation: requestPdu.type,
@@ -4288,12 +4327,14 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					mibRequests[i].setValue = requestPdu.varbinds[i].value;
 				}
 				handlers[i] = providerNode.provider.handler;
+console.log(`loc 3: handler[${i}]=`, handlers[i]);
 			}
 		}
 
 		(function (savedIndex) {
 			var responseVarbind;
 			mibRequests[savedIndex].done = function (error) {
+console.log(`loc 4: error=`, error);
 				if ( error ) {
 					if ( responsePdu.errorStatus == ErrorStatus.NoError && error.errorStatus != ErrorStatus.NoError ) {
 						responsePdu.errorStatus = error.errorStatus;
@@ -4307,6 +4348,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 				} else {
 					if ( requestPdu.type == PduType.SetRequest ) {
 						mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
+                        mib.emit("agentSetValue", instanceNode);
 					}
 					if ( ( requestPdu.type == PduType.GetNextRequest || requestPdu.type == PduType.GetBulkRequest ) &&
 							requestPdu.varbinds[savedIndex].type == ObjectType.EndOfMibView ) {
@@ -4482,6 +4524,7 @@ Agent.prototype.close  = function() {
 };
 
 Agent.create = function (options, callback, mib) {
+console.log("Agent.create: options=", options);
 	var agent = new Agent (options, callback, mib);
 	agent.listener.startListening ();
 	return agent;

--- a/index.js
+++ b/index.js
@@ -4334,8 +4334,10 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					oid: requestPdu.varbinds[i].oid
 				});
 
-				mibRequests[i].setType = requestPdu.varbinds[i].type;
-				mibRequests[i].setValue = requestPdu.varbinds[i].value;
+				if ( requestPdu.type == PduType.SetRequest ) {
+					mibRequests[i].setType = requestPdu.varbinds[i].type;
+					mibRequests[i].setValue = requestPdu.varbinds[i].value;
+				}
 				handlers[i] = providerNode.provider.handler;
 			}
 		}

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -348,7 +348,6 @@ var MIB = function (dir) {
                                                 // Object[Symbols[i - 2]]['ObjectName'] = Symbols[i - 2];
                                             });
                                         }
-
                                     } else {
                                         var ObjectName = Symbols[r - 1];
                                         Object[ObjectName] = {};

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -348,6 +348,7 @@ var MIB = function (dir) {
                                                 // Object[Symbols[i - 2]]['ObjectName'] = Symbols[i - 2];
                                             });
                                         }
+
                                     } else {
                                         var ObjectName = Symbols[r - 1];
                                         Object[ObjectName] = {};


### PR DESCRIPTION
A provider now has a `maxAccess` member that limits what operations
are allowed. A `get` request requires at least "read-only" access, and
a `set` request requires at least "read-write".