### PR TITLE
Test case to show that snmpwalk aborts early

### DIFF
--- a/example/snmp-agent-modules.js
+++ b/example/snmp-agent-modules.js
@@ -1,0 +1,380 @@
+let             snmp;
+let             mib;
+let             agent;
+let             store;
+let             authorizer;
+
+Promise.resolve()
+  .then(
+    () =>
+    {
+      snmp = require ("../");
+
+      // Create the MIB up front, so we have access to it
+      mib = mib = snmp.createMib();
+
+      // Create the SNMP Agent
+      agent = snmp.createAgent(
+        {
+          //
+          // TODO:
+          // add proper options here, including auth, priv keys
+          //
+          port : 1611
+        },
+        (e, data) =>
+        {
+          if (e)
+          {
+            console.error("Agent callback:", e);
+            return;
+          }
+        },
+        mib);
+    })
+  .then(
+    () =>
+    {
+      // Create the module store which additionally reads in the
+      // base modules
+      store = snmp.createModuleStore();
+
+      // Load additional base files not in the net-snmp default list,
+      // but needed by our non-base modules
+      [
+        "IPV6-TC"
+      ].forEach(
+        (module) =>
+        {
+          store.loadFromFile(`mibs/${module}.txt`);
+        });
+
+      // Load non-base modules
+      [
+        "RSU-MIB"
+      ].forEach(
+        (module) =>
+        {
+          // let             jsonModule;
+          let             providers;
+
+          // Retrieve this file
+          store.loadFromFile(`mibs/${module}.txt`);
+
+          // Fetch providers for this module
+          providers = store.getProvidersForModule(module);
+
+          // Register the providers
+          agent.getMib().registerProviders(providers);
+        });
+    })
+  .then(
+    () =>
+    {
+      // Add providers for each of our dynamic values
+      addDynamicProviders();
+    })
+  .then(
+    () =>
+    {
+      // Ensure there is an instance for each table object
+      mib.addTableRow(
+        "rsuSRMStatusEntry",
+        [
+          1, "1234", 18, 1, 172, 1000, "07e10a071722", "", "hello world", 1, 1
+        ]);
+      mib.addTableRow(
+        "rsuIFMStatusEntry",
+        [
+          1, "1234", 18, 1, 172, 1, 1
+        ]);
+      mib.addTableRow(
+        "rsuDsrcForwardEntry",
+        [
+          1, "1234", "20010333002200EF0000000000000001", 1024, 1, -80, 3, "", "", 1, 1
+        ]);
+      mib.addTableRow(
+        "rsuInterfaceLogEntry",
+        [
+          1, 1, 15, 2, 1, "eth0"
+        ]);
+      mib.addTableRow(
+        "rsuDsrcChannelModeEntry",
+        [
+          1, "radio1", 1, 172, 173
+        ]);
+      mib.addTableRow(
+        "rsuWsaServiceEntry",
+        [
+          1, "1234", 4, "", "20010333002200EF0000000000000001", 1024, 172, 1
+        ]);
+      mib.addTableRow(
+        "rsuMessageCountsByPsidEntry",
+        [
+          1, "1234", 0, 1
+        ]);
+      mib.addTableRow(
+        "rsuSetSlaveEntry",
+        [
+          1, "20010333002200EF0000000000000001", 1
+        ]);
+      
+
+      // Ensure there is an instance for each scalar object
+      Object.keys(mib.providers).forEach(
+        (name) =>
+        {
+          let             entry = mib.providers[name];
+
+          // Is this a scalar or a table?
+          switch(entry.type)
+          {
+          case 1 :      // scalar
+            switch(entry.scalarType)
+            {
+            case 2 : // "Integer" :
+              mib.setScalarValue(name, 0);
+              break;
+
+            case 4 : //  "OctetString" :
+              mib.setScalarValue(name, "");
+              break;
+
+            case 6 : // "OID":
+              mib.setScalarValue(name, "0.0");
+              break;
+
+            case 65 : // "Counter" :
+              mib.setScalarValue(name, 0);
+              break;
+
+            default :
+              console.log("Not setting scalar value for ", entry);
+              break;
+            }
+            break;
+
+          case 2 :      // table
+//            console.log(`Adding initial table row entry for ${name}`);
+//            mib.addTableRow(name, [ 1, "", "", "", "", "", "", "", "", "", "", "", "", "", "" ]);
+            break;
+          }
+        });
+
+      mib.setScalarValue("rsuSysObjectID", "1.0.15628.4.1.6");
+
+      //
+      // DEBUG CODE...
+      console.log("MIB provider nodes:");
+      console.log(JSON.stringify(
+        mib.providerNodes,
+        (key, value) =>
+        {
+          return [ "parent", "address" ].includes(key) ? undefined : value;
+        },
+        "  "));
+      console.log("");
+      console.log("");
+
+      // Show current MIB values
+      console.log("MIB dump:");
+      mib.dump();
+      // ...DEBUG CODE
+      //
+
+      // Specify the community
+      authorizer = agent.getAuthorizer();
+      authorizer.addCommunity("public"); // TODO: select community name
+    });
+
+
+function makeDateTime()
+{
+  const       timestamp = new Date();
+
+  // Convert to SNMPv2-TC's DateAndTime octet string format
+  const       year = timestamp.getUTCFullYear();
+  const       month = timestamp.getUTCMonth() + 1;
+  const       day = timestamp.getUTCDate();
+  const       hour = timestamp.getUTCHours();
+  const       minutes = timestamp.getUTCMinutes();
+  const       seconds = timestamp.getUTCSeconds();
+  const       decisecs = timestamp.getUTCMilliseconds() / 100;
+  const       smartbuffer = require("smart-buffer");
+  const       SmartBuffer = smartbuffer.SmartBuffer;
+  const       octetstring = new SmartBuffer();
+
+  octetstring.writeUInt16BE(year);
+  octetstring.writeUInt8(month);
+  octetstring.writeUInt8(day);
+  octetstring.writeUInt8(hour);
+  octetstring.writeUInt8(minutes);
+  octetstring.writeUInt8(seconds);
+  octetstring.writeUInt8(decisecs);
+
+  return octetstring.toBuffer();
+
+}
+
+
+
+/**
+ * Add all of our dynamic providers
+ */
+function addDynamicProviders()
+{
+  addScalarProvider(
+    {
+      name         : "rsuContMacAddress",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.1",
+      scalarType   : snmp.ObjectType.OctetString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) =>  "does not exist" // TODO
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuAltMacAddress",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.2",
+      scalarType   : snmp.ObjectType.OctetString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => "does not exist" // TODO
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuGpsStatus",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.3",
+      scalarType   : snmp.ObjectType.Integer32,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => 12              // TODO
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuGpsOutputString",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.6",
+      scalarType   : snmp.ObjectType.OctetString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => "todo"          // TODO
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuTimeSincePowerOn",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.1",
+      scalarType   : snmp.ObjectType.Counter32,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => require("os").uptime()
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuLastLoginTime",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.3",
+      scalarType   : snmp.ObjectType.DateAndTime,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => makeDateTime()
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuLastLoginUser",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.4",
+      scalarType   : snmp.ObjectType.DisplayString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => "derrell"
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuLastLoginSource",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.5",
+      scalarType   : snmp.ObjectType.DisplayString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => "localhost"
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuLastRestartTime",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.6",
+      scalarType   : snmp.ObjectType.DateAndTime,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => makeDateTime()
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuIntTemp",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.16.7",
+      scalarType   : snmp.ObjectType.Integer32,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => -100            // TODO
+    });
+
+  addScalarProvider(
+    {
+      name         : "rsuFirmwareVersion",
+      type         : snmp.MibProviderType.Scalar,
+      oid          : "1.0.15628.4.1.17.2",
+      scalarType   : snmp.ObjectType.DisplayString,
+      maxAccess    : snmp.MaxAccess["read-only"],
+      innerHandler : (mibRequest) => "0.1"
+    });
+}
+
+/**
+ * Add a scalar provider
+ *
+ * @param registrationInfo
+ *   This is equivalent to the data passed to `mib.registerProvider`
+ *   except that instead of a complete handler, only the "inner" portion
+ *   of the handler is provided, i.e., that portioni which is unique to
+ *   this method. The boilerplate registering the provider and adding this
+ *   new provider information to an existing node are done internally and
+ *   need not be done by the `innerHandler`.
+ *
+ *   The provided `registrationInfo` map should contain the following
+ *   fields:
+ *     - name {String}
+ *     - type {snmp.MibProviderType}
+ *     - oid {String}
+ *     - scalarType {snmp.ObjectType}
+ *     - innerHandler {Function}
+ */
+function addScalarProvider(registrationInfo)
+{
+  const           { name, innerHandler } = registrationInfo;
+  let             handler;
+
+  // Create the full handler given the inner handler
+  handler =
+    async (mibRequest) =>
+    {
+      const           value = await innerHandler(mibRequest);
+
+      mib.setScalarValue(name, value);
+      mibRequest.done();
+    };
+
+  // Replace the inner handler with the full handler
+  registrationInfo.handler = handler;
+  delete registrationInfo.innerHandler;
+
+  // Register this new provider
+  mib.registerProvider(registrationInfo);
+
+  // Replace the provider of the previously-created node with this one
+  mib.addProviderToNode(registrationInfo);
+}

--- a/index.js
+++ b/index.js
@@ -4295,6 +4295,9 @@ Agent.prototype.isAllowed = function (pduType, provider, instanceNode) {
 			// GetRequests require at least read-only access
 			return maxAccess >= MaxAccess["read-only"];
 
+//		case "GetNextRequest":
+//			return true;
+
 		default:
 			// Disallow other pdu types (TODO: verify no others needed)
 			return false;

--- a/lib/mibs/IPV6-TC.txt
+++ b/lib/mibs/IPV6-TC.txt
@@ -1,0 +1,67 @@
+IPV6-TC DEFINITIONS ::= BEGIN
+
+IMPORTS
+     Integer32                FROM SNMPv2-SMI
+     TEXTUAL-CONVENTION       FROM SNMPv2-TC;
+
+-- definition of textual conventions
+Ipv6Address ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "2x:"
+     STATUS       current
+     DESCRIPTION
+       "This data type is used to model IPv6 addresses.
+        This is a binary string of 16 octets in network
+        byte-order."
+     SYNTAX       OCTET STRING (SIZE (16))
+
+Ipv6AddressPrefix ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "2x:"
+     STATUS       current
+     DESCRIPTION
+       "This data type is used to model IPv6 address
+       prefixes. This is a binary string of up to 16
+       octets in network byte-order."
+     SYNTAX       OCTET STRING (SIZE (0..16))
+
+Ipv6AddressIfIdentifier ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "2x:"
+     STATUS       current
+     DESCRIPTION
+       "This data type is used to model IPv6 address
+       interface identifiers. This is a binary string
+        of up to 8 octets in network byte-order."
+     SYNTAX      OCTET STRING (SIZE (0..8))
+
+Ipv6IfIndex ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "d"
+     STATUS       current
+     DESCRIPTION
+       "A unique value, greater than zero for each
+       internetwork-layer interface in the managed
+       system. It is recommended that values are assigned
+       contiguously starting from 1. The value for each
+       internetwork-layer interface must remain constant
+       at least from one re-initialization of the entity's
+       network management system to the next
+
+       re-initialization."
+     SYNTAX       Integer32 (1..2147483647)
+
+Ipv6IfIndexOrZero ::= TEXTUAL-CONVENTION
+     DISPLAY-HINT "d"
+     STATUS       current
+     DESCRIPTION
+         "This textual convention is an extension of the
+         Ipv6IfIndex convention.  The latter defines
+         a greater than zero value used to identify an IPv6
+         interface in the managed system.  This extension
+         permits the additional value of zero.  The value
+         zero is object-specific and must therefore be
+         defined as part of the description of any object
+         which uses this syntax.  Examples of the usage of
+         zero might include situations where interface was
+         unknown, or when none or all interfaces need to be
+         referenced."
+     SYNTAX       Integer32 (0..2147483647)
+
+END

--- a/lib/mibs/RSU-MIB.txt
+++ b/lib/mibs/RSU-MIB.txt
@@ -1,0 +1,1561 @@
+RSU-MIB DEFINITIONS ::= BEGIN
+IMPORTS
+    MODULE-IDENTITY, OBJECT-TYPE, Integer32,
+    Counter32, NOTIFICATION-TYPE                    FROM SNMPv2-SMI
+    TEXTUAL-CONVENTION, DateAndTime, RowStatus,
+    PhysAddress, DisplayString, MacAddress          FROM SNMPv2-TC
+    MODULE-COMPLIANCE, OBJECT-GROUP                 FROM SNMPv2-CONF
+    Ipv6Address                                     FROM IPV6-TC;
+
+
+rsuMIB MODULE-IDENTITY
+    LAST-UPDATED    "201812060000Z" -- Midnight Dec 6, 2018
+    ORGANIZATION    "OmniAir Technical Working Group"
+    CONTACT-INFO    "Chair:     Dmitri Khijniak
+                     email:     info@omniair.org
+                     Location:
+    https://github.com/certificationoperatingcouncil/COC_TestSpecs/blob/master/AppNotes/RSU/RSU-MIB.txt"
+    DESCRIPTION     "Updated RSU 4.1 MIB for OmniAir RSU certification"
+    
+    REVISION        "201812060000Z"
+    DESCRIPTION     "Updated comments for rsuAltMacAddress, rsuMibVersion.
+                     rsuMessageCountsByPsidCounts changed to read-only"
+    REVISION        "201806260000Z"
+    DESCRIPTION     "Changes to match clarifications in FAQ regarding 
+                     the RSU 4.1 Spec dated March 30, 2018"
+    REVISION        "201805180000Z"
+    DESCRIPTION     "Contribution from WSP and 7layers to RSU 4.1 MIB
+                     Cleanup and expansion of comments to remove ambiguity"
+    REVISION        "201710020000Z"
+    DESCRIPTION     "Allow RsuPsidTC length up to 4,
+                     rsuWsaProviderContext length to 32 (match dot3),
+                     rsuSRMPayload length to 2302 (match dot3)"
+    REVISION        "201702200000Z"
+    DESCRIPTION     "Corrections to INTEGER/Integer32 types and typos"
+    REVISION        "201610310000Z"
+    DESCRIPTION     "Final Draft for RSU 4.1 Spec."
+    REVISION        "201608310230Z"
+    DESCRIPTION     "Second Draft for RSU 4.1 Spec."
+    REVISION        "201608120230Z"
+    DESCRIPTION     "First Draft for RSU 4.1 Spec."
+    REVISION        "201606270245Z"
+    DESCRIPTION     "Combining input from Vendors"
+    REVISION        "201404150000Z"            -- 15 April 2014 midnight
+    DESCRIPTION     "RSU MIB Definitions"
+    ::= { iso std(0) rsu(15628) version(4) 1 }
+
+
+RsuTableIndex ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT   "d"
+    STATUS         current
+    DESCRIPTION
+        "A valid range of values for use in table indices"
+    SYNTAX         Integer32 (1..2147483647)
+
+RsuPsidTC ::= TEXTUAL-CONVENTION
+    DISPLAY-HINT   "4x"
+    STATUS         current
+    DESCRIPTION
+        "PSID associated with a DSRC message.
+        PSID is formatted per IEEE1609.12-2016 Table 2 as P-encoded hex values,
+        e.g. BSM = 0x20, TIM = 0x8003, WSA = 0x8007, IProuting = 0xEFFFFFFE.
+        For those PSIDs less than 4 octets in length, The RSU should only 
+        require the significant octets be provided. For example, if the desired
+        PSID is 0x20, then the RSU should accept a supplied value of 0x20.
+        It should not need to be padded to a 4-octet length."
+    SYNTAX         OCTET STRING (SIZE(1..4))
+
+rsuContMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents an 802 MAC address of the DSRC Radio operating in
+         Continuous Mode. 
+         MAC is represented in the 'canonical' order defined by
+         IEEE 802.1a, i.e., as if it were transmitted least significant
+         bit first, even though 802.5 (in contrast to other 802.x protocols)
+         requires MAC addresses to be transmitted most significant bit first."
+    ::= { rsuMIB 1 }
+-- add entries for multiple antennas
+
+rsuAltMacAddress OBJECT-TYPE
+    SYNTAX      MacAddress
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Represents an 802 MAC address of the DSRC Radio operating in
+         Alternating Mode. If DSRC Radio operating in Alternating Mode uses 
+         two separate MAC addresses for the Control and Service channels, 
+         this entry contains the MAC address used for the Control channel.
+         MAC is represented in the 'canonical' order defined
+         by IEEE 802.1a, i.e., as if it were transmitted least significant
+         bit first, even though 802.5 (in contrast to other 802.x protocols)
+         requires MAC addresses to be transmitted most significant bit first."
+    ::= { rsuMIB 2 }
+
+rsuGpsStatus OBJECT-TYPE
+    SYNTAX       Integer32 (0..15)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Provides the number of GPS Satellites RSU's internal GPS receiver is
+         tracking"
+    ::= { rsuMIB 3 }
+
+rsuSRMStatusTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuSRMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Provides configuration information for each Store & Repeat 
+         message to be sent by an RSU."
+    ::= { rsuMIB 4 }
+
+rsuSRMStatusEntry OBJECT-TYPE
+    SYNTAX RsuSRMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A row describing RSU Store and Repeat Message."
+    INDEX   { rsuSRMIndex }
+    ::= {rsuSRMStatusTable 1 }
+
+RsuSRMStatusEntry ::= SEQUENCE {
+    rsuSRMIndex             RsuTableIndex,
+    rsuSRMPsid              RsuPsidTC,
+    rsuSRMDsrcMsgId         Integer32,
+    rsuSRMTxMode            INTEGER,
+    rsuSRMTxChannel         Integer32,
+    rsuSRMTxInterval        Integer32,
+    rsuSRMDeliveryStart     OCTET STRING,
+    rsuSRMDeliveryStop      OCTET STRING,
+    rsuSRMPayload           OCTET STRING,
+    rsuSRMEnable            INTEGER,
+    rsuSRMStatus            RowStatus
+}
+
+rsuSRMIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Store and Repeat Message Index"
+    ::= { rsuSRMStatusEntry 1 }
+
+rsuSRMPsid OBJECT-TYPE
+    SYNTAX       RsuPsidTC
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Store and Repeat Message PSID."
+    ::= { rsuSRMStatusEntry 2 }
+
+rsuSRMDsrcMsgId OBJECT-TYPE
+    SYNTAX       Integer32
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC Message ID as defined in J2735.
+         For the J2735 version 2016-03, some sample values are:
+         MAP = 18, SPAT = 19, TIM = 31"
+    ::= { rsuSRMStatusEntry 3 }
+
+rsuSRMTxMode OBJECT-TYPE
+    SYNTAX       INTEGER { cont(0), alt(1) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC mode set for Store and Repeat Message transmit,
+         Continuous (0) or Alternating (1)"
+    ::= { rsuSRMStatusEntry 4 }
+
+rsuSRMTxChannel OBJECT-TYPE
+    SYNTAX       Integer32 (172..184)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC channel set for Store and Repeat Message transmit"
+    ::= { rsuSRMStatusEntry 5 }
+
+rsuSRMTxInterval OBJECT-TYPE
+    SYNTAX       Integer32 (1..2147483647)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Time interval in milliseconds between two successive
+         Store and Repeat Messages"
+    ::= { rsuSRMStatusEntry 6 }
+
+rsuSRMDeliveryStart OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(0|6))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Store and Repeat Message delivery start time.
+         This time is supplied in the format of the first
+         6 octets in the DateAndTime field as defined in RFC2579.
+         Example: October 7, 2017 at 11:34 PM UTC would be encoded
+         as 07e10a071722"
+    ::= { rsuSRMStatusEntry 7 }
+
+rsuSRMDeliveryStop OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(0|6))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Store and Repeat Message delivery stop time.
+         See comment for rsuSRMDeliveryStart for the format."
+    ::= { rsuSRMStatusEntry 8 }
+
+rsuSRMPayload OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(0..2302))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Payload of Store and Repeat message. 
+        For SAE J2735-032016 messages, this object includes encoded MessageFrame.
+         Length limit derived from dot3MIB."
+    ::= { rsuSRMStatusEntry 9 }
+
+rsuSRMEnable OBJECT-TYPE
+    SYNTAX       INTEGER { off(0), on(1) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Set this bit to enable transmission of the message
+         0=off, 1=on"
+    ::= { rsuSRMStatusEntry 10 }
+
+rsuSRMStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Create (4) or Destroy (6) row entry"
+    ::= { rsuSRMStatusEntry 11 }
+
+rsuIFMStatusTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuIFMStatusEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Provides configuration parameters for each Immediate
+         Forward message sent by an RSU. Only IFMs sent to the 
+         appropriate port that match those preconfigured in
+         rsuIFMStatusTable via SNMP will be forwarded. All others 
+         will be ignored. IFM messages must be encoded per Appendix C."
+    ::= { rsuMIB 5 }
+
+rsuIFMStatusEntry OBJECT-TYPE
+    SYNTAX       RsuIFMStatusEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "A row describing RSU Immediate Forward Message Status"
+    INDEX   { rsuIFMIndex }
+    ::= {rsuIFMStatusTable 1 }
+
+RsuIFMStatusEntry ::= SEQUENCE {
+    rsuIFMIndex             RsuTableIndex,
+    rsuIFMPsid              RsuPsidTC,
+    rsuIFMDsrcMsgId         Integer32,
+    rsuIFMTxMode            INTEGER,
+    rsuIFMTxChannel         Integer32,
+    rsuIFMEnable            INTEGER,
+    rsuIFMStatus            RowStatus
+}
+
+rsuIFMIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Immediate Forward Message Index"
+    ::= { rsuIFMStatusEntry 1 }
+
+rsuIFMPsid OBJECT-TYPE
+    SYNTAX       RsuPsidTC
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Immediate Forward Message PSID."
+    ::= { rsuIFMStatusEntry 2}
+
+rsuIFMDsrcMsgId OBJECT-TYPE
+    SYNTAX       Integer32
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Immediate Forward Message DSRC Message ID
+        See clarifications in rsuSRMDsrcMsgId"
+    ::= { rsuIFMStatusEntry 3 }
+
+rsuIFMTxMode OBJECT-TYPE
+    SYNTAX       INTEGER { cont(0), alt(1) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Immediate Forward Message Transmit Mode
+         Alternating (1) or Continuous (0)"
+    ::= { rsuIFMStatusEntry 4 }
+
+rsuIFMTxChannel OBJECT-TYPE
+    SYNTAX       Integer32 (172..184)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC channel set for Immediate Forward Message transmit"
+    ::= { rsuIFMStatusEntry 5 }
+
+rsuIFMEnable OBJECT-TYPE
+    SYNTAX       INTEGER { off(0), on(1) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Set this bit to enable transmission of the message
+         0=off, 1=on"
+    ::= { rsuIFMStatusEntry 6 }
+
+rsuIFMStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Create (4) or Destroy (6) row entry"
+    ::= { rsuIFMStatusEntry 7}
+
+rsuSysObjectID OBJECT-TYPE
+    SYNTAX       OBJECT IDENTIFIER
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+       "The vendor's authoritative identification of the network
+        management subsystem contained in the entity. This OID
+        is allocated within the DSRC subtree (1.0.15628.4.1) and
+        provides an easy and unambiguous means for determining
+        'what kind of box' is being managed. Presence of rsuSysObjectID.0
+        indicates an RSU. The returned value may be a starting OID 
+        pointing to the vendor-specific MIB subtree."
+    ::= { rsuMIB 6 }
+
+rsuDsrcForwardTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuDsrcForwardEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Contains the DSRC PSID being forwarded to a network host,
+         the IP Address and port number of the destination host, as
+         well as other configuration parameters as defined."
+    ::= { rsuMIB 7}
+
+rsuDsrcForwardEntry OBJECT-TYPE
+    SYNTAX       RsuDsrcForwardEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "A row describing RSU Message Forwarding"
+    INDEX   { rsuDsrcFwdIndex }
+    ::= {rsuDsrcForwardTable 1 }
+
+RsuDsrcForwardEntry ::= SEQUENCE {
+    rsuDsrcFwdIndex              RsuTableIndex,
+    rsuDsrcFwdPsid               RsuPsidTC,
+    rsuDsrcFwdDestIpAddr         Ipv6Address,
+    rsuDsrcFwdDestPort           Integer32,
+    rsuDsrcFwdProtocol           INTEGER,
+    rsuDsrcFwdRssi               Integer32,
+    rsuDsrcFwdMsgInterval        Integer32,
+    rsuDsrcFwdDeliveryStart      OCTET STRING,
+    rsuDsrcFwdDeliveryStop       OCTET STRING,
+    rsuDsrcFwdEnable             INTEGER,
+    rsuDsrcFwdStatus             RowStatus
+}
+
+rsuDsrcFwdIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "DSRC Message Forward Table Index "
+    ::= { rsuDsrcForwardEntry 1 }
+
+rsuDsrcFwdPsid OBJECT-TYPE
+    SYNTAX       RsuPsidTC
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC Message Forward PSID"
+    ::= { rsuDsrcForwardEntry 2 }
+
+rsuDsrcFwdDestIpAddr OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "IPv6 address of the Remote Server for DSRC Message Forwarding Destination.
+        Example: IPv6 address 2001:333:22:ef::1 would be encoded as 
+        20010333002200EF0000000000000001"
+    ::= { rsuDsrcForwardEntry 3 }
+
+rsuDsrcFwdDestPort OBJECT-TYPE
+    SYNTAX       Integer32 (1024..65535)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC Message Forward Destination Server Port Number"
+    ::= { rsuDsrcForwardEntry 4 }
+
+rsuDsrcFwdProtocol OBJECT-TYPE
+    SYNTAX       INTEGER { tcp(1), udp(2) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "DSRC Message Forward Transport Protocol between RSU and Server"
+    ::= { rsuDsrcForwardEntry 5 }
+
+rsuDsrcFwdRssi OBJECT-TYPE
+    SYNTAX       Integer32 (-100..-60)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Minimum signal strength level (in dBm units) of received DSRC messages that are to
+         be forwarded to the server"
+    ::= { rsuDsrcForwardEntry 6 }
+
+rsuDsrcFwdMsgInterval OBJECT-TYPE
+    SYNTAX       Integer32 (1..9)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Interval of messages which RSU forwards to Server.
+         An interval of 1 means the RSU will forward every message.
+         An interval of 2 means it will forward every other message (50% of
+         messages received), and an interval of 5 means it will forward every 
+         fifth message (20% of messages received)."
+    ::= { rsuDsrcForwardEntry 7 }
+
+rsuDsrcFwdDeliveryStart OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(0|6))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Start time for RSU to start forwarding DSRC Messages to Server
+        See comment for rsuSRMDeliveryStart for the format."
+    ::= { rsuDsrcForwardEntry 8 }
+
+rsuDsrcFwdDeliveryStop OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(0|6))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Stop time for RSU to stop forwarding DSRC Messages to Server
+        See comment for rsuSRMDeliveryStart for the format."
+    ::= { rsuDsrcForwardEntry 9 }
+
+rsuDsrcFwdEnable OBJECT-TYPE
+    SYNTAX       INTEGER { off(0), on(1) }
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Enable (1) or Disable (0) forwarding DSRC messages to the
+        defined address."
+    ::= { rsuDsrcForwardEntry 10 }
+
+rsuDsrcFwdStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Create (4) or Destroy (6) row entry "
+    ::= { rsuDsrcForwardEntry 11 }
+
+rsuGpsOutput OBJECT IDENTIFIER ::= { rsuMIB 8 }
+
+rsuGpsOutputPort OBJECT-TYPE
+    SYNTAX       Integer32 (1024..65535)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Remote host port number to which to send the GPS string."
+    ::= { rsuGpsOutput 1 }
+
+rsuGpsOutputAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Remote host IPv6 address to which to send the GPS string.
+        See example in rsuDsrcFwdDestIpAddr"
+    ::= { rsuGpsOutput 2 }
+
+rsuGpsOutputInterface OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Local interface on which to output the GPS string"
+    ::= { rsuGpsOutput 3 }
+
+rsuGpsOutputInterval OBJECT-TYPE
+    SYNTAX       Integer32 (1..18000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Interval at which to send the GPS GPGGA NMEA String
+        to external server, in seconds."
+    ::= { rsuGpsOutput 4 }
+
+rsuGpsOutputString OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..100))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains GPS NMEA GPGGA output string."
+    ::= { rsuGpsOutput 5 }
+
+rsuGpsRefLat OBJECT-TYPE
+    SYNTAX       Integer32 (-900000000..900000000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the reference GPS latitude for validation of
+         reported GPS latitude in 10^-7 degrees."
+    ::= { rsuGpsOutput 6 }
+
+rsuGpsRefLon OBJECT-TYPE
+    SYNTAX       Integer32 (-1800000000..1800000000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the reference GPS longitude for validation of
+         reported GPS longitude in 10^-7 degrees."
+    ::= { rsuGpsOutput 7 }
+
+rsuGpsRefElv OBJECT-TYPE
+    SYNTAX       Integer32 (-100000..1000000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the reference GPS elevation (in centimeters). 
+        The reference GPS elevation is compared to the 
+         reported GPS reading from the built-in GPS receiver"
+    ::= { rsuGpsOutput 8 }
+
+rsuGpsMaxDeviation OBJECT-TYPE
+    SYNTAX       Integer32 (1..2000000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the maximum allowable deviation (radius in centimeters)
+         for comparison between the actual 3D GPS coordinates of the RSU unit 
+         (latitude, longitude and elevation) and the reference GPS coordinates 
+         in rsuGpsRefLat, rsuGpsRefLon and rsuGpsRefElv."
+    ::= { rsuGpsOutput 9 }
+
+rsuInterfaceLogTable OBJECT-TYPE
+    SYNTAX       SEQUENCE OF RsuInterfaceLogEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Provides configuration information for capturing log files
+         for each communication interface. The index represents the
+         interface for which these configurations will apply"
+    ::= { rsuMIB 9 }
+
+rsuInterfaceLogEntry OBJECT-TYPE
+    SYNTAX       RsuInterfaceLogEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "A row describing RSU Interface Log"
+    INDEX   { rsuIfaceLogIndex }
+    ::= {rsuInterfaceLogTable 1 }
+
+RsuInterfaceLogEntry ::= SEQUENCE {
+        rsuIfaceLogIndex             RsuTableIndex,
+        rsuIfaceGenerate             INTEGER,
+        rsuIfaceMaxFileSize          Integer32,
+        rsuIfaceMaxFileTime          Integer32,
+        rsuIfaceLogByDir             INTEGER,
+        rsuIfaceName                 DisplayString
+}
+
+rsuIfaceLogIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Interface Logging Index"
+    ::= { rsuInterfaceLogEntry 1 }
+
+rsuIfaceGenerate OBJECT-TYPE
+    SYNTAX       INTEGER { off(0), on(1) }
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Enable (1) or Disable (0) interface logging."
+    ::= { rsuInterfaceLogEntry 2 }
+
+rsuIfaceMaxFileSize OBJECT-TYPE
+    SYNTAX       Integer32 (1..40)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Maximum Interface Log File Size in megabytes,
+         default is 5."
+    ::= { rsuInterfaceLogEntry 3 }
+
+rsuIfaceMaxFileTime OBJECT-TYPE
+    SYNTAX       Integer32 (1..48)
+    MAX-ACCESS read-write
+    STATUS current
+    DESCRIPTION
+        "Maximum Collection time for Interface Logging in hours,
+         default is 24."
+    ::= { rsuInterfaceLogEntry 4 }
+
+rsuIfaceLogByDir OBJECT-TYPE
+    SYNTAX       INTEGER { off(0), on(1) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Sets whether or not to separate the log files by direction."
+    ::= { rsuInterfaceLogEntry 5 }
+
+rsuIfaceName OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Identifies the name of the interface for which the logs defined
+         by this row are to be managed."
+    ::= { rsuInterfaceLogEntry 6 }
+
+rsuSecCredReq OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (1))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Provides configuration parameters for when an RSU should
+         request new 1609.2 security credentials, in days, before
+         existing credentials expire"
+    ::= { rsuMIB 10 }
+
+rsuSecCredAttachInterval OBJECT-TYPE
+    SYNTAX       Integer32 (1..100)
+    MAX-ACCESS   read-write
+    STATUS current
+    DESCRIPTION
+        "Provides configuration parameters for the number of packets when 
+         an RSU will attach 1609.2 security credentials to a WAVE Short Message Protocol
+         (WSMP) Messages. E.g. if it is set to 20, then every 20th WSMP message should 
+         have a cert attached."
+    ::= { rsuMIB 11 }
+
+rsuDsrcChannelModeTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuDsrcChannelModeEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Provides Continuous and Alternating Channel Mode
+         configurations for each DSRC interface.
+         The index value represents the interface for which these
+         configurations will apply"
+    ::= { rsuMIB 12  }
+
+rsuDsrcChannelModeEntry OBJECT-TYPE
+    SYNTAX       RsuDsrcChannelModeEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "A row describing RSU Interface Log"
+    INDEX   { rsuDCMIndex }
+    ::= {rsuDsrcChannelModeTable 1 }
+
+RsuDsrcChannelModeEntry ::= SEQUENCE {
+    rsuDCMIndex       RsuTableIndex,
+    rsuDCMRadio       DisplayString,
+    rsuDCMMode        INTEGER,
+    rsuDCMCCH         Integer32,
+    rsuDCMSCH         Integer32
+}
+
+rsuDCMIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Radio Interface Channel Mode Index"
+    ::= { rsuDsrcChannelModeEntry 1 }
+
+rsuDCMRadio OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Name of the radio that the configuration relates to."
+    ::= { rsuDsrcChannelModeEntry 2 }
+
+rsuDCMMode OBJECT-TYPE
+    SYNTAX       INTEGER { cont(0), alt(1) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "DSRC Channel Mode. Continuous Mode(0), Alternating Mode (1)
+        For Continous Mode, specify the same Channel number in rsuDCMCCH
+        and rsuDCMSCH."
+    ::= { rsuDsrcChannelModeEntry 3 }
+
+rsuDCMCCH OBJECT-TYPE
+    SYNTAX       Integer32 (172..184)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Channel number used as Control Channel. In Alternating Mode
+        this channel will be used during time slot 0."
+    ::= { rsuDsrcChannelModeEntry 4 }
+
+rsuDCMSCH OBJECT-TYPE
+    SYNTAX       Integer32 (172..184)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Channel number used as Service Channel. In Alternating Mode 
+        this channel will be used during time slot 1."
+    ::= { rsuDsrcChannelModeEntry 5 }
+
+rsuWsaServiceTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuWsaServiceEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Holds general configuration parameters for the RSU WAVE
+         Service Advertisement."
+    ::= { rsuMIB 13 }
+
+rsuWsaServiceEntry OBJECT-TYPE
+    SYNTAX RsuWsaServiceEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A row describing RSU WSA Service "
+    INDEX   { rsuWsaIndex }
+    ::= {rsuWsaServiceTable 1 }
+
+RsuWsaServiceEntry ::= SEQUENCE {
+        rsuWsaIndex                 RsuTableIndex,
+        rsuWsaPsid                  RsuPsidTC,
+        rsuWsaPriority              Integer32,
+        rsuWsaProviderContext       OCTET STRING,
+        rsuWsaIpAddress             Ipv6Address,
+        rsuWsaPort                  Integer32,
+        rsuWsaChannel               Integer32,
+        rsuWsaStatus                RowStatus
+}
+
+rsuWsaIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "WSA Service Index"
+    ::= { rsuWsaServiceEntry 1 }
+
+rsuWsaPsid OBJECT-TYPE
+    SYNTAX       RsuPsidTC
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "WSA Service PSID"
+    ::= { rsuWsaServiceEntry 2 }
+
+rsuWsaPriority OBJECT-TYPE
+    SYNTAX       Integer32 (0..63)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Priority of WSA Service Advertised"
+    ::= { rsuWsaServiceEntry 3 }
+
+rsuWsaProviderContext OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE (0..31))
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "WSA Service Specific Provider Context 1-31 Octets, size(0) 
+        to omit it from WSA"
+    ::= { rsuWsaServiceEntry 4 }
+
+rsuWsaIpAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "IPv6 address of WSA Service Advertised"
+    ::= { rsuWsaServiceEntry 5 }
+
+rsuWsaPort OBJECT-TYPE
+    SYNTAX       Integer32 (1024..65535)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Port Number of WSA Service Advertised "
+    ::= { rsuWsaServiceEntry 6 }
+
+rsuWsaChannel OBJECT-TYPE
+    SYNTAX       Integer32 (172..184)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "The Channel number on which the advertised service is provided."
+    ::= { rsuWsaServiceEntry 7 }
+
+rsuWsaStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Create (4) or Destroy (6) rows"
+    ::= { rsuWsaServiceEntry 8 }
+
+rsuWraConfiguration OBJECT IDENTIFIER ::= { rsuMIB 14 }
+
+rsuWraIpPrefix OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "IPv6 address prefix of WRA Service Advertised"
+    ::= { rsuWraConfiguration 1 }
+
+rsuWraIpPrefixLength OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(1))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Length of IPv6 address prefix of WRA Service Advertised.
+         A 64-bit prefix is '0x40', a 60-bit prefix is '0x3c' and a
+         52-bit prefix is '0x34'"
+    ::= { rsuWraConfiguration 2 }
+-- DK make it integer
+
+rsuWraGateway OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "IPv6 address of Gateway of WRA Service Advertised"
+    ::= { rsuWraConfiguration 3 }
+
+rsuWraPrimaryDns OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "IPv6 address of Primary DNS Server in WSA WRA structure"
+    ::= { rsuWraConfiguration 4 }
+
+rsuMessageStats OBJECT IDENTIFIER ::= { rsuMIB 15 }
+-- DK: need reference to radio if RSU has multiple radios
+rsuAltSchMsgSent OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages sent on Alternating Service Channel since
+         start of service."
+    ::= { rsuMessageStats 1 }
+
+rsuAltSchMsgRcvd OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages received on Alternating Service Channel since
+         start of service."
+    ::= { rsuMessageStats 2 }
+
+rsuAltCchMsgSent OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages sent on Alternating Control Channel since
+         start of service."
+    ::= { rsuMessageStats 3 }
+
+rsuAltCchMsgRcvd OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages received on Alternating Control Channel since
+         start of service."
+    ::= { rsuMessageStats 4 }
+
+rsuContSchMsgSent OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages sent on Continuous Service Channel since
+         start of service."
+    ::= { rsuMessageStats 5 }
+
+rsuContSchMsgRcvd OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages received on Continuous Service Channel since
+         start of service."
+    ::= { rsuMessageStats 6 }
+
+rsuContCchMsgSent OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages sent on Continuous Control Channel since
+         start of service."
+    ::= { rsuMessageStats 7 }
+
+rsuContCchMsgRcvd OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Number of messages sent on Continuous Control Channel since
+         start of service."
+    ::= { rsuMessageStats 8 }
+
+rsuMessageCountsByPsidTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuMessageCountsByPsidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "Provides a count of transmitted messages sorted by PSID.
+         Each row is a different PSID. The rows can be created by
+         the agent automatically based PSIDs used in detected messages.
+         Also, user can create or delete rows to tailor the list of 
+         monitored PSIDs."
+    ::= { rsuMessageStats 9 }
+
+rsuMessageCountsByPsidEntry OBJECT-TYPE
+    SYNTAX RsuMessageCountsByPsidEntry
+    MAX-ACCESS  not-accessible
+    STATUS      current
+    DESCRIPTION
+        "A row describing the number of messages transmitted "
+    INDEX   { rsuMessageCountsByPsidIndex }
+    ::= { rsuMessageCountsByPsidTable 1 }
+
+RsuMessageCountsByPsidEntry ::= SEQUENCE {
+    rsuMessageCountsByPsidIndex        RsuTableIndex,
+    rsuMessageCountsByPsidId           RsuPsidTC,
+    rsuMessageCountsByPsidCounts       Counter32,
+    rsuMessageCountsByPsidRowStatus    RowStatus
+}
+
+rsuMessageCountsByPsidIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Message Count Index"
+    ::= { rsuMessageCountsByPsidEntry 1 }
+
+rsuMessageCountsByPsidId OBJECT-TYPE
+    SYNTAX       RsuPsidTC
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Contains the PSID for this row of message counts."
+    ::= { rsuMessageCountsByPsidEntry 2 }
+
+rsuMessageCountsByPsidCounts OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the number of messages sent or received for this PSID"
+    ::= { rsuMessageCountsByPsidEntry 3 }
+
+rsuMessageCountsByPsidRowStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "RowStatus as defined in RFC2579 with minimum support
+         for active = 1, notInService = 2, notReady = 3,
+         createAndGo = 4 or destroy = 6"
+    ::= { rsuMessageCountsByPsidEntry 4 }
+
+rsuSystemStats OBJECT IDENTIFIER ::= { rsuMIB 16 }
+
+rsuTimeSincePowerOn OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the number of seconds that have elapsed
+         since the RSU was last powered on."
+    ::= { rsuSystemStats 1 }
+
+rsuTotalRunTime OBJECT-TYPE
+    SYNTAX       Counter32
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the total number of seconds that the system has been operational
+        (i.e. in Operate or Standby states) since the RSU was first powered on."
+    ::= { rsuSystemStats 2 }
+
+rsuLastLoginTime OBJECT-TYPE
+    SYNTAX       DateAndTime
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the date/time when the last user logged in."
+    ::= { rsuSystemStats 3 }
+
+rsuLastLoginUser OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the username of the last user to log in."
+    ::= { rsuSystemStats 4 }
+
+rsuLastLoginSource OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..64))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the hostname or IP address of the remote host 
+         from which the last user logged in."
+    ::= { rsuSystemStats 5 }
+
+rsuLastRestartTime OBJECT-TYPE
+    SYNTAX       DateAndTime
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the Date and Time when the RSU was last restarted."
+    ::= { rsuSystemStats 6 }
+
+rsuIntTemp OBJECT-TYPE
+    SYNTAX       Integer32 (-100..100)
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the internal temperature of the RSU in degrees of Celsius."
+    ::= { rsuSystemStats 7 }
+
+rsuSysDescription OBJECT IDENTIFIER ::= { rsuMIB 17 }
+
+rsuMibVersion OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the version of this MIB supported by this RSU, 
+        e.g. rsuMIB 4.1 rev201812060000Z"
+    ::= { rsuSysDescription 1 }
+
+rsuFirmwareVersion OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the version of firmware running on this RSU."
+    ::= { rsuSysDescription 2 }
+
+rsuLocationDesc OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..140))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains a description of the installation location of this RSU."
+    ::= { rsuSysDescription 3 }
+
+rsuID OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..32))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the ID given to this RSU."
+    ::= { rsuSysDescription 4 }
+
+rsuManufacturer OBJECT-TYPE
+    SYNTAX       DisplayString (SIZE(0..32))
+    MAX-ACCESS   read-only
+    STATUS       current
+    DESCRIPTION
+        "Contains the name of the manufacturer of this RSU."
+    ::= { rsuSysDescription 5 }
+
+rsuSysSettings OBJECT IDENTIFIER ::= { rsuMIB 18 }
+
+rsuTxPower OBJECT-TYPE
+    SYNTAX       Integer32 (0..100)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Sets the actual output power of the RSU antennas as a
+         percentage of full power supported by this RSU.
+         rsuTxPower can be considered a default transmit power 
+         level to be used if a power level is not defined by 
+         an application. The power level defined by the application 
+         would take precedence."
+    ::= { rsuSysSettings 1 }
+
+rsuNotifyIpAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the IPv6 address of the SNMP Manager that will
+         receive the SNMP Notifications. (SNMP traps)"
+    ::= { rsuSysSettings 2 }
+
+rsuNotifyPort OBJECT-TYPE
+    SYNTAX       Integer32 (0..65535)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the port number of the SNMP Manager that will
+         receive the SNMP Notifications. (SNMP traps) Default is 162."
+    ::= { rsuSysSettings 3 }
+
+rsuSysLogCloseDay OBJECT-TYPE
+    SYNTAX       INTEGER {  monday(1), tuesday(2), wednesday(3),
+                            thursday(4), friday(5), saturday(6),
+                            sunday(7) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the day of the week on which to close the system
+         log file. Default is Sunday."
+    ::= { rsuSysSettings 4 }
+
+rsuSysLogCloseTime OBJECT-TYPE
+    SYNTAX       OCTET STRING (SIZE(3))
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the time of day at which to close the system
+         log file.  Default is 23:59:00 UTC.
+         The format of this time should be provided as a 3-octet
+         field containing HHMMSS. Example: The default time 23:59:00
+         would be given as 173b00."
+    ::= { rsuSysSettings 5 }
+
+rsuSysLogDeleteDay OBJECT-TYPE
+    SYNTAX       INTEGER {  monday(1), tuesday(2), wednesday(3),
+                            thursday(4), friday(5), saturday(6),
+                            sunday(7) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the day of the week on which to delete the old system
+         log files. Default is Sunday."
+    ::= { rsuSysSettings 6 }
+
+rsuSysLogDeleteAge OBJECT-TYPE
+    SYNTAX       Integer32
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the minimum age at which to delete old log files.
+         Default is 30 days."
+    ::= { rsuSysSettings 7 }
+-- System Status
+
+rsuSystemStatus OBJECT IDENTIFIER ::= { rsuMIB 19}
+
+rsuChanStatus OBJECT-TYPE
+    SYNTAX  INTEGER {
+            bothOp (0), --both Continuous and Alternating modes are operational
+            altOp (1),  --Alternating mode is operational,
+                        --Continuous mode is not operational
+            contOp (2), --Continuous mode is operational,
+                        --Alternating mode is not operational
+            noneOp (3)  --neither Continuous nor Alternating mode is operational
+            }
+    MAX-ACCESS  read-only
+    STATUS      current
+    DESCRIPTION
+        "Indicates which channel modes are operating.
+         Note: Operating means the device is functioning
+         as designed, configured, and intended"
+    ::= { rsuSystemStatus 1 }
+-- Situation Data
+
+rsuSitData OBJECT IDENTIFIER ::= { rsuMIB 20 }
+
+rsuSdcDestIpAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the IPv6 address of the Situation Data Clearinghouse."
+    ::= { rsuSitData 1 }
+
+rsuSdcDestPort OBJECT-TYPE
+    SYNTAX       Integer32 (1024..65535)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the port on which the Situation Data Clearinghouse
+         will receive data."
+    ::= { rsuSitData 2 }
+
+rsuSdcInterval OBJECT-TYPE
+    SYNTAX       Integer32 (1..18000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the interval in seconds at which the RSU will send
+         data to the Situation Data Clearinghouse."
+    ::= { rsuSitData 3 }
+
+rsuSdwIpAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the IPv6 address of the Situation Data Warehouse."
+    ::= { rsuSitData 4 }
+
+rsuSdwPort OBJECT-TYPE
+    SYNTAX       Integer32 (1024..65535)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Contains the port on which the Situation Data Warehouse
+         will receive requests from the RSU."
+    ::= { rsuSitData 5 }
+-- RSU Set
+
+rsuSet OBJECT IDENTIFIER ::= { rsuMIB 21 }
+
+rsuSetRole OBJECT-TYPE
+    SYNTAX       INTEGER { master (0), slave (1) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "The role of the RSU in a set (master = 0 or slave = 1)"
+    ::= { rsuSet 1 }
+
+rsuSetEnable OBJECT-TYPE
+    SYNTAX       INTEGER { independent (0), set (1) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "The status of the RSU set.  0 is not operating in a set;
+         1 is operating in a set."
+    ::= { rsuSet 2 }
+
+rsuSetSlaveTable OBJECT-TYPE
+    SYNTAX SEQUENCE OF RsuSetSlaveEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Holds the configuration parameters for the slave RSUs."
+    ::= { rsuSet 3 }
+
+rsuSetSlaveEntry OBJECT-TYPE
+    SYNTAX       RsuSetSlaveEntry
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "A row describing the configuration of each slave RSU."
+    INDEX   { rsuSetSlaveIndex }
+    ::= { rsuSetSlaveTable 1 }
+
+RsuSetSlaveEntry ::= SEQUENCE {
+    rsuSetSlaveIndex            RsuTableIndex,
+    rsuSetSlaveIpAddress        Ipv6Address,
+    rsuSetSlaveRowStatus        RowStatus
+}
+
+rsuSetSlaveIndex OBJECT-TYPE
+    SYNTAX       RsuTableIndex
+    MAX-ACCESS   not-accessible
+    STATUS       current
+    DESCRIPTION
+        "Slave RSU index"
+    ::= { rsuSetSlaveEntry 1 }
+
+rsuSetSlaveIpAddress OBJECT-TYPE
+    SYNTAX       Ipv6Address
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Contains the IPv6 address of each slave RSU.  One
+         slave per row."
+    ::= { rsuSetSlaveEntry 2 }
+
+rsuSetSlaveRowStatus OBJECT-TYPE
+    SYNTAX       RowStatus
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Create (4) or Destroy (6) rows"
+    ::= { rsuSetSlaveEntry 3 }
+-- RSU Mode
+
+rsuMode OBJECT-TYPE
+    SYNTAX       INTEGER { standby (2), operate (4), off (16) }
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Specifies the current mode of operation of the RSU and 
+        provides capability to transition the device into a new mode, 
+        e.g. from the current mode to off, etc."
+    ::= { rsuMIB 99 }
+-- Asynchronous Messages
+
+--
+-- DJL MODS
+--
+djlTestInt OBJECT-TYPE
+    SYNTAX       INTEGER (1024..65535)
+    MAX-ACCESS   read-create
+    STATUS       current
+    DESCRIPTION
+        "Derrell's test integer scalar."
+    DEFVAL       { 23 }
+    ::= { rsuMIB 200 }
+
+rsuAsync OBJECT IDENTIFIER ::= { rsuMIB 100 }
+-- Notifications
+
+rsuNotifications OBJECT IDENTIFIER ::= { rsuAsync 0 }
+messageFileIntegrityError NOTIFICATION-TYPE
+-- should start with rsu DK
+    OBJECTS      { rsuAlertLevel, rsuMsgFileIntegrityMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should immediately report integrity check
+         errors on select store-and-forward messages to the SNMP
+         manager."
+    ::= { rsuNotifications 1 }
+
+rsuSecStorageIntegrityError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuSecStorageIntegrityMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should immediately report integrity check
+         errors in secure storage to the SNMP manager."
+    ::= { rsuNotifications 2 }
+
+rsuTamperAlert NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuTamperAlertMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report any tampering to the enclosure
+         to the SNMP manager."
+    ::= { rsuNotifications 3 }
+
+rsuAuthError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuAuthMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report an error in authorization
+         to the SNMP manager."
+    ::= { rsuNotifications 4 }
+
+rsuSignatureVerifyError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuSignatureVerifyMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report any signature verification errors
+         to the SNMP manager."
+    ::= { rsuNotifications 5 }
+
+rsuAccessError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuAccessMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report an access error or rejection due to
+         a violation of the Access Control List."
+    ::= { rsuNotifications 6 }
+
+rsuTimeSourceLost NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuTimeSourceLostMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report to the SNMP manager that a
+         time source was lost after vendor-defined timeout interval."
+    ::= { rsuNotifications 7 }
+
+rsuClockSkewError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuClockSkewMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report to the SNMP manager a skew rate in
+         the clock signal that exceeds a vendor-defined value."
+    ::= { rsuNotifications 8 }
+
+rsuTimeSourceMismatch NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuTimeSourceMismatchMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report to the SNMP manager a deviation between
+         two time sources that exceeds a vendor-defined threshold."
+    ::= { rsuNotifications 9 }
+
+rsuGpsAnomaly NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuGpsAnomalyMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report any anomalous GPS readings
+         to the SNMP manager."
+    ::= { rsuNotifications 10 }
+
+rsuGpsDeviationError NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuGpsDeviationMsg }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report to the SNMP manager a deviation in
+         GPS position that is greater than the configured value."
+    ::= { rsuNotifications 11 }
+
+rsuGpsNmeaNotify NOTIFICATION-TYPE
+    OBJECTS      { rsuAlertLevel, rsuGpsOutputString }
+    STATUS       current
+    DESCRIPTION
+        "The SNMP agent should report the NMEA string to the SNMP manager
+         at the configured interval. This object is used in conjunction with 
+         the Notification Object provided by rsuGpsOutputString."
+    ::= { rsuNotifications 12 }
+
+rsuNotificationObjects OBJECT IDENTIFIER ::= { rsuAsync 1 }
+-- Notification Objects
+
+rsuMsgFileIntegrityMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing an Active Message
+         Integrity error."
+    ::= { rsuNotificationObjects 1 }
+
+rsuSecStorageIntegrityMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing a secure storage
+         Integrity error."
+    ::= { rsuNotificationObjects 2 }
+
+rsuTamperAlertMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing an enclosure
+         tampering error."
+    ::= { rsuNotificationObjects 3 }
+
+rsuAuthMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing an authorization error."
+    ::= { rsuNotificationObjects 4 }
+
+rsuSignatureVerifyMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing a signature verification
+         error."
+    ::= { rsuNotificationObjects 5 }
+
+rsuAccessMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing an error or rejection
+         due to Access Control List rules."
+    ::= { rsuNotificationObjects 6 }
+
+rsuTimeSourceLostMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message indicating a time source
+         was lost."
+    ::= { rsuNotificationObjects 7 }
+
+rsuClockSkewMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing that a vendor-defined
+         clock skew rate was exceeded."
+    ::= { rsuNotificationObjects 8 }
+
+rsuTimeSourceMismatchMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing a deviation between
+         two time sources that exceeds a vendor-defined threshold."
+    ::= { rsuNotificationObjects 9 }
+
+rsuGpsAnomalyMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message detailing an anomaly that was
+         detected in the GPS signal."
+    ::= { rsuNotificationObjects 10 }
+
+rsuGpsDeviationMsg OBJECT-TYPE
+    SYNTAX       DisplayString
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "Contains the error message indicating that the reported GPS
+         position differs from the reference by more than the
+         allowed deviation."
+    ::= { rsuNotificationObjects 11 }
+
+rsuGpsNmeaNotifyInterval OBJECT-TYPE
+    SYNTAX       Integer32 (0..18000)
+    MAX-ACCESS   read-write
+    STATUS       current
+    DESCRIPTION
+        "Sets the repeat interval in seconds for the snmp notifications 
+        (i.e. traps) containing the GPS NMEA GPGGA string. 
+        Default is 0 (disabled)."
+    ::= { rsuNotificationObjects 12 }
+
+rsuAlertLevel OBJECT-TYPE
+    SYNTAX       INTEGER {
+                            info(0),
+                            notice(1),
+                            warning(2),
+                            error(3),
+                            critical(4)
+                        }
+    MAX-ACCESS   accessible-for-notify
+    STATUS       current
+    DESCRIPTION
+        "The level of importance of the notification."
+    ::= { rsuNotificationObjects 13 }
+END


### PR DESCRIPTION
This test case demonstrates the problem described in #145 after the merge of #146. With index.js as it exists in master, this command fails to walk the entire tree:

`snmpwalk -v2c -c public localhost:1611 1.0.15628`

But if the case GetNextRequest at index.js:4293 is commented out, and instead, the two commented-out lines at 4298 are uncommented, the snmpwalk walks the entire tree.

Sorry this isn't as minimal as I would have liked, to demonstrate the problem...
