### PR TITLE
Add delete add failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 notes.txt
 example/test.js
+persistent.json

--- a/README.md
+++ b/README.md
@@ -2305,6 +2305,42 @@ event type is shown here:
     - providerName
     - values (array of values for the table row)
 
+- tableRowDeleted
+  - Issued when a RowStatus column's value is set to "destroy" and the
+    row has been deleted.
+  - members:
+    - eventType ("tableRowDeleted"
+    - oid
+    - providerName
+    - row (array of row index values)
+
+- set
+  - Issued when a Set operation occurs
+  - members:
+    - eventType ("set")
+    - oid
+    - providerName
+    - value
+
+- getEndOfMibView
+  - Issued when a GetNext or GetBulk request is issued, and the end of
+    the mib view has been reached
+  - members:
+    - eventType ("getEndOfMibView")
+    - requestType
+    - oid
+    - providerName
+    - value
+
+- get
+  - Issued when a Get operation occurs
+  - members:
+    - eventType ("get")
+    - requestType
+    - oid
+    - providerName
+    - value
+
 - ERRnoInstance
   - Issued when no instance node can be found or automatically
     created, for the provided oid
@@ -2344,42 +2380,6 @@ event type is shown here:
     - oid
     - errorStatus (ErrorStatus.InconstentValue)
     - errorIndex
-
-- tableRowDeleted
-  - Issued when a RowStatus column's value is set to "destroy" and the
-    row has been deleted.
-  - members:
-    - eventType ("tableRowDeleted"
-    - oid
-    - providerName
-    - row (array of row index values)
-
-- set
-  - Issued when a Set operation occurs
-  - members:
-    - eventType ("set")
-    - oid
-    - providerName
-    - value
-
-- getEndOfMibView
-  - Issued when a GetNext or GetBulk request is issued, and the end of
-    the mib view has been reached
-  - members:
-    - eventType ("getEndOfMibView")
-    - requestType
-    - oid
-    - providerName
-    - value
-
-- get
-  - Issued when a Get operation occurs
-  - members:
-    - eventType ("get")
-    - requestType
-    - oid
-    - providerName
-    - value
 
 Any single request can potentially result in multiple events, particularly in light of automatic creation of objects. For example, a request to create a new row by setting a RowStatus column to "createAndGo" (4) will result in three agent events:
 

--- a/README.md
+++ b/README.md
@@ -2146,12 +2146,11 @@ provider, then the instance will not, by default, be automatically
 created.
 
 The default handling of instance creation can be overridden by
-providing a handler to the method `setScalarReadCreateHandler`. This
-method takes one parameter, the handler to be used for generating the
-value of a scalar instance to be automatically created. The handler is
-passed a single argument, the provider for the scalar. The method must
-return either the value to be assigned to the newly-created instance;
-or `undefined` to indicate that the instance should not be created.
+providing a handler in a provider, called, `createHandler`. The
+handler is passed a single argument, the provider for the scalar. The
+method must return either the value to be assigned to the
+newly-created instance; or `undefined` to indicate that the instance
+should not be created.
 
 An example handler method, accomplishing the default behavior, looks
 like this:
@@ -2169,8 +2168,8 @@ function scalarReadCreateHandler (provider) {
 }
 ```
 
-Automatic instance creation of scalars can be disabled entirely by
-calling `setScalarReadCreateHandler(null);`.
+Automatic instance creation of table rows can be disabled entirely by
+setting `createHandler` to null.
 
 ### Table rows
 
@@ -2191,9 +2190,7 @@ specified in any column other than index or Status columns, the row
 will not be automatically created.
 
 The default handling of row creation can be overridden by providing a
-handler to the method, `setTableRowStatusHandler`. This method takes
-one parameter, the handler to be used for generating the values for
-each column of the row to be automatically created. The handler is
+handler in a provider, called, `createHandler`. The handler is
 passed three arguments:
 
 - the provider for the table
@@ -2249,7 +2246,7 @@ function tableRowStatusHandler(provider, action, row) {
 ```
 
 Automatic instance creation of table rows can be disabled entirely by
-calling `setTableRowStatusHandler(null);`.
+setting `createHandler` to null.
 
 ### Mapping from MIB files
 

--- a/README.md
+++ b/README.md
@@ -2229,8 +2229,8 @@ function tableRowStatusHandler(provider, action, row) {
 				values.push(rowIndexValues.shift());
 			} else if ( columnInfo.rowStatus ) {
 				// It's the RowStatus column. Replace the action with the appropriate state
-				values.push( action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"] );
-			} else if ( "defVal" in tc[index] ) {
+				values.push( RowStatus[action] );
+			} else if ( "defVal" in columnInfo] ) {
 				// Neither index nor RowStatus column, so use the default value
 				values.push( columnInfo.defVal );
 			} else {

--- a/README.md
+++ b/README.md
@@ -2304,6 +2304,7 @@ event type is shown here:
     - oid
     - providerName
     - values (array of values for the table row)
+    - row (array of row index values)
 
 - tableRowDeleted
   - Issued when a RowStatus column's value is set to "destroy" and the
@@ -2321,6 +2322,9 @@ event type is shown here:
     - oid
     - providerName
     - value
+  - additional members, if provider's type is Table
+    - row (array of row index values)
+    - column
 
 - getEndOfMibView
   - Issued when a GetNext or GetBulk request is issued, and the end of

--- a/README.md
+++ b/README.md
@@ -2288,7 +2288,7 @@ event type is shown here:
 
 - autoCreateScalar
   - Issued when a scalar has `maxAccess` set to "read-create" and the
-  scalar does not exist when it is read
+  scalar does not exist when it is read or set
   - members:
     - eventType ("autoCreateScalar")
     - oid
@@ -2309,7 +2309,7 @@ event type is shown here:
   - Issued when a RowStatus column's value is set to "destroy" and the
     row has been deleted.
   - members:
-    - eventType ("tableRowDeleted"
+    - eventType ("tableRowDeleted")
     - oid
     - providerName
     - row (array of row index values)

--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ The Agent Extensibility (AgentX) Protocol specifies these PDUs in RFC 2741:
 - `2 - read-only`
 - `3 - read-write`
 - `4 - read-create`
-};
 
 # snmp.RowStatus
 Status values
@@ -295,13 +294,13 @@ Actions
 
 
 # snmp.AgentEvent
-## Error event types
+Error event types
 - `-1 - ERRnoInstance`
 - `-2 - ERRnoProvider`
 - `-3 - ERRnoAccess`
 - `-4 - ERRbadRowStatusAction`
 
-## Successful action events
+Successful action events
 - `0 - autoCreateScalar`
 - `1 - autoCreateTableRow`
 - `2 - tableRowDeleted`
@@ -2263,111 +2262,6 @@ function tableRowStatusHandler(provider, action, row) {
 Automatic instance creation of table rows can be disabled entirely by
 setting `createHandler` to null.
 
-## Agent monitoring
-Requests from a manager to the agent can be monitored, by registering
-an event handler function. The event handler function is called with a
-single argument, a map. In all cases, the map has an `eventType`
-member which is one of the `snmp.AgentEvent` values. Members `oid` and
-`providerName` (when available) are also present. Depending on the
-`eventType`, other members vary. The complete set of members for each
-event type is shown here:
-
-- autoCreateScalar
-  - Issued when a scalar has `maxAccess` set to "read-create" and the
-  scalar does not exist when it is read
-  - eventType ("autoCreateScalar")
-  - oid
-  - providerName
-  - value
-
-- autoCreateTableRow
-  - Issued when a table row is created as a result of a RowStatus
-    column's value being set to "createAndGo" (4) or "createAndWait"
-    (5), and the row is found to not exist.
-  - eventType ("autoCreateTableRow")
-  - oid
-  - providerName
-  - values (array of values for the table row)
-
-- ERRnoInstance
-  - Issued when no instance node can be found or automatically
-    created, for the provided oid
-  - eventType ("ERRnoInstance")
-  - requestType
-  - oid
-  - errorStatus (ErrorStatus.NoError)
-  - errorType (ObjectType.NoSuchObject)
-
-- ERRnoProvider
-  - Issued when no provider node can be found for the ascertained
-    instance node.
-  - eventType ("ERRnoProvider")
-  - requestType
-  - oid
-  - errorStatus (ErrorStatus.NoError)
-  - errorType (ObjectType.NoSuchInstance)
-
-- ERRnoAccess
-  - Issued when an attempt at `maxAccess` violation is made
-  - eventType ("ERRnoAccess")
-  - requestType
-  - oid
-  - errorStatus (ErrorStatus.NoAccess)
-  - errorIndex
-
-- ERRbadRowStatusAction
-  - Issued when an illegal value is set in the RowStatus column. There
-    are six legal values of RowStatus (see snmp.RowStatus), of which
-    five may be set. The value "notReady" may not be set.
-  - eventType ("ERRbadRowStatusAction")
-  - requestType
-  - oid
-  - errorStatus (ErrorStatus.InconstentValue)
-  - errorIndex
-
-- tableRowDeleted
-  - Issued when a RowStatus column's value is set to "destroy" and the
-    row has been deleted.
-  - eventType ("tableRowDeleted"
-  - oid
-  - providerName
-  - row (array of row index values)
-
-- set
-  - Issued when a Set operation occurs
-  - eventType ("set")
-  - oid
-  - providerName
-  - value
-
-- getEndOfMibView
-  - Issued when a GetNext or GetBulk request is issued, and the end of
-    the mib view has been reached
-  - eventType ("getEndOfMibView")
-  - requestType
-  - oid
-  - providerName
-  - value
-
-- get
-  - Issued when a Get operation occurs
-  - eventType ("get")
-  - requestType
-  - oid
-  - providerName
-  - value
-
-Any single request can potentially result in multiple events, particularly in light of automatic creation of objects. For example, a request to create a new row by setting a RowStatus column to "createAndGo" (4) will result in three agent events:
-
-- autoCreateTableRow
-  - The automatically-ascertained column values, e.g., from `defVal`
-    settings, will be available in the `values` member
-- set
-  - Shows changing to the new value of the RowStatus column, "active" (1)
-- get
-  - Retrieving the value of the column, to be returned as the result
-    of the Set request
-
 ### Mapping from MIB files
 
 When a MIB is read from a file using `ModuleStore`'s `loadFromFile`
@@ -2382,6 +2276,121 @@ needed for automatic creation of scalar objects or table rows, the
 methods `Mib.setScalarDefaultValue` and `Mib.setTableRowDefaultValues`
 may be used to conveniently add defaults after the MIB files are
 loaded.
+
+## Agent events
+Requests from a manager to the agent can be monitored, by registering
+an event handler function. The event handler function is called with a
+single argument, a map. In all cases, the map has an `eventType`
+member which is one of the `snmp.AgentEvent` values. Members `oid` and
+`providerName` (when available) are also present. Depending on the
+`eventType`, other members vary. The complete set of members for each
+event type is shown here:
+
+- autoCreateScalar
+  - Issued when a scalar has `maxAccess` set to "read-create" and the
+  scalar does not exist when it is read
+  - members:
+    - eventType ("autoCreateScalar")
+    - oid
+    - providerName
+    - value
+
+- autoCreateTableRow
+  - Issued when a table row is created as a result of a RowStatus
+    column's value being set to "createAndGo" (4) or "createAndWait"
+    (5), and the row is found to not exist.
+  - members:
+    - eventType ("autoCreateTableRow")
+    - oid
+    - providerName
+    - values (array of values for the table row)
+
+- ERRnoInstance
+  - Issued when no instance node can be found or automatically
+    created, for the provided oid
+  - members:
+    - eventType ("ERRnoInstance")
+    - requestType
+    - oid
+    - errorStatus (ErrorStatus.NoError)
+    - errorType (ObjectType.NoSuchObject)
+
+- ERRnoProvider
+  - Issued when no provider node can be found for the ascertained
+    instance node.
+  - members:
+    - eventType ("ERRnoProvider")
+    - requestType
+    - oid
+    - errorStatus (ErrorStatus.NoError)
+    - errorType (ObjectType.NoSuchInstance)
+
+- ERRnoAccess
+  - Issued when an attempt at `maxAccess` violation is made
+  - members:
+    - eventType ("ERRnoAccess")
+    - requestType
+    - oid
+    - errorStatus (ErrorStatus.NoAccess)
+    - errorIndex
+
+- ERRbadRowStatusAction
+  - Issued when an illegal value is set in the RowStatus column. There
+    are six legal values of RowStatus (see snmp.RowStatus), of which
+    five may be set. The value "notReady" may not be set.
+  - members:
+    - eventType ("ERRbadRowStatusAction")
+    - requestType
+    - oid
+    - errorStatus (ErrorStatus.InconstentValue)
+    - errorIndex
+
+- tableRowDeleted
+  - Issued when a RowStatus column's value is set to "destroy" and the
+    row has been deleted.
+  - members:
+    - eventType ("tableRowDeleted"
+    - oid
+    - providerName
+    - row (array of row index values)
+
+- set
+  - Issued when a Set operation occurs
+  - members:
+    - eventType ("set")
+    - oid
+    - providerName
+    - value
+
+- getEndOfMibView
+  - Issued when a GetNext or GetBulk request is issued, and the end of
+    the mib view has been reached
+  - members:
+    - eventType ("getEndOfMibView")
+    - requestType
+    - oid
+    - providerName
+    - value
+
+- get
+  - Issued when a Get operation occurs
+  - members:
+    - eventType ("get")
+    - requestType
+    - oid
+    - providerName
+    - value
+
+Any single request can potentially result in multiple events, particularly in light of automatic creation of objects. For example, a request to create a new row by setting a RowStatus column to "createAndGo" (4) will result in three agent events:
+
+- autoCreateTableRow
+  - The automatically-ascertained column values, e.g., from `defVal`
+    settings, will be available in the `values` member
+- set
+  - Shows changing to the new value of the RowStatus column, "active" (1)
+- get
+  - Retrieving the value of the column, to be returned as the result
+    of the Set request
 
 # Using This Module: Module Store
 

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -197,11 +197,45 @@ mib.setTableRowDefaultValues(
     undefined          // rsuWsaStatus           RowStatus
   ]);
 
+console.log("before first add");
+mib.dump ({
+	leavesOnly: false,
+    showProviders: true,
+    showValues: true,
+    showTypes: true
+});
+
 mib.addTableRow("rsuWsaServiceEntry", [ 1, 4, 1 ]);
 console.log("Row: ", JSON.stringify(mib.getTableRowCells("rsuWsaServiceEntry", [1])));
+
+console.log("after first add");
+mib.dump ({
+	leavesOnly: false,
+    showProviders: true,
+    showValues: true,
+    showTypes: true
+});
+
 mib.deleteTableRow("rsuWsaServiceEntry", [ 1 ] );
+
+console.log("after delete");
+mib.dump ({
+	leavesOnly: false,
+    showProviders: true,
+    showValues: true,
+    showTypes: true
+});
+
 mib.addTableRow("rsuWsaServiceEntry", [ 1, 4, 1 ]);
 console.log("Row: ", JSON.stringify(mib.getTableRowCells("rsuWsaServiceEntry", [1])));
+
+console.log("after second add");
+mib.dump ({
+	leavesOnly: false,
+    showProviders: true,
+    showValues: true,
+    showTypes: true
+});
 
 var changes;
 
@@ -226,13 +260,6 @@ try {
 	changes = {};
 }
 */
-
-mib.dump ({
-	leavesOnly: true,
-    showProviders: true,
-    showValues: true,
-    showTypes: true
-});
 
 // var data = mib.getTableColumnDefinitions ("ifTable");
 // var data = mib.getTableCells ("ifTable", true);

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -59,6 +59,7 @@ scalarProvider = {
     type: snmp.MibProviderType.Scalar,
     oid: "1.3.6.1.2.1.11.30",
     scalarType: snmp.ObjectType.Integer,
+//	createHandler: (provider) => 42,
     maxAccess: snmp.MaxAccess['read-create'],
 	defVal: 1
 };
@@ -68,6 +69,7 @@ var tableProvider = {
     name: "ifTable",
     type: snmp.MibProviderType.Table,
     oid: "1.3.6.1.2.1.2.2.1",
+//	createHandler: (provider, action, row) => [ row[0], "Locally-created", 24, snmp.RowStatus[action] ],
     maxAccess: snmp.MaxAccess['not-accessible'],
 	rowStatusColumn: 99,
     tableColumns: [

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -198,8 +198,7 @@ agent.setAgentEventHandler(
 		var data;
 		var isChanged = false;
 
-		switch ( message.eventType )
-		{
+		switch ( message.eventType ) {
 			case "autoCreateScalar":
 			case "set":
 				if ( "row" in message ) {

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -16,7 +16,7 @@ var callback = function (error, data) {
     if ( error ) {
         console.error (error);
     } else {
-        console.log (JSON.stringify(data.pdu.varbinds, null, 2));
+        console.log ("callback: " + JSON.stringify(data.pdu.varbinds, null, 2));
     }
 };
 
@@ -165,3 +165,8 @@ acm.setCommunityAccess ("private", snmp.AccessLevel.ReadWrite);
 acm.setUserAccess ("fred", snmp.AccessLevel.ReadWrite);
 console.log ("private = ", acm.getCommunityAccess ("private"));
 console.log (acm.getCommunitiesAccess ());
+
+agent.setAgentEventHandler(
+	(message) => {
+	  console.log("Agent event: ", message);
+	});

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -168,5 +168,5 @@ console.log (acm.getCommunitiesAccess ());
 
 agent.setAgentEventHandler(
 	(message) => {
-	  console.log("Agent event: ", message);
+		console.log("Agent event: ", message);
 	});

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -149,13 +149,14 @@ agent.setScalarReadCreateHandler(
 				console.log("No default scalar value available:", provider);
 				return undefined;
 		}
-	});
+    }
+);
 
 
 agent.setTableRowStatusHandler(
 	(provider, action, row) => {
-		const			  tc = provider.tableColumns;
-		const			  RowStatus = snmp.RowStatus;
+		const tc = provider.tableColumns;
+		const RowStatus = snmp.RowStatus;
 
 		function defVal(col, valueIfNotFound) {
 			if (typeof tc[col].defVal == "undefined") {
@@ -166,21 +167,21 @@ agent.setTableRowStatusHandler(
 		}
 
 		switch (provider.name) {
-		case "ifTable" :
-			return (
-				[
-					Array.isArray(row) ? row[0] : row,
-					defVal(1, "Hello world!"),
-					defVal(2, 24),
-					(action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"])
-				]);
+            case "ifTable" :
+                return (
+                    [
+                        Array.isArray(row) ? row[0] : row,
+                        defVal(1, "Hello world!"),
+                        defVal(2, 24),
+                        (action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"])
+                    ]
+                );
 
-		default :
-			return undefined;
-		}
-	});
-  
-
+            default :
+                return undefined;
+        }
+    }
+);
 
 var mib = agent.getMib ();
 mib.setScalarValue ("sysDescr", "Rage inside the machine!");

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -1,5 +1,6 @@
 var snmp = require ("../");
 var getopts = require ("getopts");
+var fs = require("fs");
 
 var options = getopts(process.argv.slice(2));
 
@@ -140,6 +141,28 @@ mib.addTableRow ("ifTable", [2, "eth0", 6, 2]);
 
 //console.log (JSON.stringify (providers, null, 2));
 
+var changes;
+
+// If there's a persistent store, make its specified changes
+try {
+	changes = JSON.parse(fs.readFileSync("persistent.json"));
+
+	for (var providerName in changes) {
+		var change = changes[providerName];
+		if (typeof change == "object") {
+			// table row
+			for (var rowIndex in change) {
+				mib.addTableRow(providerName, change[rowIndex]);
+			}
+		} else {
+			mib.setScalarValue(providerName, change);
+		}
+	}
+} catch (e) {
+	console.log("Could not parse persistent storage");
+	changes = {};
+}
+
 mib.dump ({
 	leavesOnly: true,
     showProviders: true,
@@ -166,7 +189,62 @@ acm.setUserAccess ("fred", snmp.AccessLevel.ReadWrite);
 console.log ("private = ", acm.getCommunityAccess ("private"));
 console.log (acm.getCommunitiesAccess ());
 
+// Demonstrate (a very poor, dangerous implementation of) persistence
 agent.setAgentEventHandler(
 	(message) => {
 		console.log("Agent event: ", message);
+
+		var index;
+		var data;
+		var isChanged = false;
+
+		switch ( message.eventType )
+		{
+			case "autoCreateScalar":
+			case "set":
+				if ( "row" in message ) {
+					index = JSON.stringify(message.row);
+					if (! changes[message.providerName]) {
+						changes[message.ProviderName] = {};
+					}
+					data = mib.getTableRowCells(message.providerName, message.row);
+					data = data.map((v) => v instanceof Buffer ? v.toString() : v);
+					changes[message.providerName][index] = data;
+				} else {
+					data = message.value;
+					data = data instanceof Buffer ? data.toString() : data;
+					changes[message.providerName] = data;
+				}
+				isChanged = true;
+				break;
+
+			case "autoCreateTableRow":
+				index = JSON.stringify(message.row);
+				if (! changes[message.providerName]) {
+					changes[message.providerName] = {};
+				}
+				data = message.values;
+				data = data.map((v) => v instanceof Buffer ? v.toString() : v);
+				changes[message.providerName][index] = data;
+				isChanged = true;
+				break;
+
+			case "tableRowDeleted":
+				index = JSON.stringify(message.row);
+				delete changes[message.providerName][index];
+				if (Object.keys(changes[message.providerName]).length === 0) {
+					delete changes[message.providerName];
+				}
+				isChanged = true;
+				break;
+
+			default:
+				break;
+		}
+
+		console.log("saving changes=", JSON.stringify(changes, null, "	"));
+
+		if (isChanged) {
+			fs.writeFileSync("persistent.json", JSON.stringify(changes, null, "	 "));
+		}
 	});

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -64,7 +64,6 @@ scalarProvider = {
 };
 agent.registerProvider (scalarProvider);
 
-
 var tableProvider = {
     name: "ifTable",
     type: snmp.MibProviderType.Table,
@@ -98,7 +97,7 @@ var tableProvider = {
                     "24": "anotherif"
                 }
             },
-			defVal: 2
+			defVal: 6
         },
         {
             number: 99,
@@ -120,72 +119,12 @@ var tableProvider = {
 };
 agent.registerProvider (tableProvider);
 
-/*
-agent.setScalarReadCreateHandler(
-	(provider) => {
-		// If there's a default value specified...
-		if (typeof provider.defVal != "undefined") {
-			// ... then use it
-			return provider.defVal;
-		}
-
-		// Choose an appropriate default value, when possible
-		switch (provider.scalarType) {
-			case snmp.ObjectType.Boolean :
-				return false;
-
-			case snmp.ObjectType.Integer :
-				return 0;
-
-			case snmp.ObjectType.OctetString :
-				return "";
-
-			case snmp.ObjectType.OID :
-				return "0.0";
-
-			case snmp.ObjectType.Counter :
-			case snmp.ObjectType.Counter64 :
-				return 0;
-
-			default :
-				console.log("No default scalar value available:", provider);
-				return undefined;
-		}
-    }
-);
-
-agent.setTableRowStatusHandler(
-	(provider, action, row) => {
-		const tc = provider.tableColumns;
-		const RowStatus = snmp.RowStatus;
-
-		function defVal(col, valueIfNotFound) {
-			if (typeof tc[col].defVal == "undefined") {
-				return valueIfNotFound;
-			}
-
-			return tc[col].defVal;
-		}
-
-		switch (provider.name) {
-			case "ifTable" :
-				return (
-					[
-						Array.isArray(row) ? row[0] : row,
-						"Hi there",
-						defVal(2, 24),
-						(action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"])
-					]
-				);
-
-			default :
-				return undefined;
-		}
-	}
-);
-*/
-
 var mib = agent.getMib ();
+
+// Modify defaults
+mib.setScalarDefaultValue ("snmpEnableAuthenTraps", 3);
+mib.setTableRowDefaultValues( "ifTable", [ undefined, "Hello world, amended!", 2, undefined ] );
+
 mib.setScalarValue ("sysDescr", "Rage inside the machine!");
 mib.addTableRow ("ifTable", [1, "lo", 24, 1]);
 mib.addTableRow ("ifTable", [2, "eth0", 6, 2]);

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -221,6 +221,7 @@ function agentHandler(message) {
 		(message) => {
 			switch ( message.eventType ) {
 				case "autoCreateScalar":
+				case "autoSet":
 				case "set":
 					if ( "row" in message ) {
 						index = JSON.stringify(message.row);

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -12,11 +12,11 @@ var snmpOptions = {
     address: null,
     accessControlModelType: snmp.AccessControlModelType.Simple,
     agentEventMethod:           // comment out ones not wanted
-        snmp.AgentEventMethod.event |
-        snmp.AgentEventMethod.mainCallback  |
-        snmp.AgentEventMethod.separateCallback  |
-        snmp.AgentEventMethod.individual  |
-        snmp.AgentEventMethod.coalesced  |
+//        snmp.AgentEventMethod.event |
+//        snmp.AgentEventMethod.mainCallback  |
+//        snmp.AgentEventMethod.separateCallback  |
+//        snmp.AgentEventMethod.individual  |
+//        snmp.AgentEventMethod.coalesced  |
         0
 };
 
@@ -150,10 +150,56 @@ mib.addTableRow ("ifTable", [2, "eth0", 6, 2]);
 // var providers = store.getProviders ("IF-MIB");
 // mib.registerProviders (providers);
 
-// console.log (JSON.stringify (mib.providers, null, 2));
+mib.registerProviders(
+[
+  {
+    "tableName": "rsuWsaServiceTable",
+    "type": 2,
+    "tableColumns": [
+      {
+        "number": 1,
+        "name": "rsuWsaIndex",
+        "type": 2,
+        "maxAccess": 0
+      },
+      {
+        "number": 3,
+        "name": "rsuWsaPriority",
+        "type": 2,
+        "maxAccess": 4
+      },
+      {
+        "number": 8,
+        "name": "rsuWsaStatus",
+        "type": 2,
+        "maxAccess": 4,
+        "rowStatus": true
+      }
+    ],
+    "tableIndex": [
+      {
+        "columnName": "rsuWsaIndex",
+        "columnNumber": 1,
+        "type": 2
+      }
+    ],
+    "maxAccess": 0,
+    "name": "rsuWsaServiceEntry",
+    "oid": "1.0.15628.4.1.13.1"
+  }
+]);
+
+mib.setTableRowDefaultValues(
+  "rsuWsaServiceEntry",
+  [
+    undefined,         // rsuWsaIndex            RsuTableIndex,
+    4,                 // rsuWsaPriority         Integer32,
+    undefined          // rsuWsaStatus           RowStatus
+  ]);
 
 var changes;
 
+/*
 // If there's a persistent store, make its specified changes
 try {
 	changes = JSON.parse(fs.readFileSync("persistent.json"));
@@ -173,6 +219,7 @@ try {
 	console.log("Could not parse persistent storage");
 	changes = {};
 }
+*/
 
 mib.dump ({
 	leavesOnly: true,

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -139,7 +139,7 @@ mib.addTableRow ("ifTable", [2, "eth0", 6, 2]);
 // var providers = store.getProviders ("IF-MIB");
 // mib.registerProviders (providers);
 
-//console.log (JSON.stringify (providers, null, 2));
+// console.log (JSON.stringify (mib.providers, null, 2));
 
 var changes;
 

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -252,11 +252,13 @@ function agentHandler(message) {
 
 				case "tableRowDeleted":
 					index = JSON.stringify(message.row);
-					delete changes[message.providerName][index];
-					if (Object.keys(changes[message.providerName]).length === 0) {
-						delete changes[message.providerName];
+					if (changes && changes[message.providerName] && changes[message.providerName][index]) {
+						delete changes[message.providerName][index];
+						if (Object.keys(changes[message.providerName]).length === 0) {
+							delete changes[message.providerName];
+						}
+						isChanged = true;
 					}
-					isChanged = true;
 					break;
 
 				default:

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -163,28 +163,6 @@ try {
 	changes = {};
 }
 
-var changes;
-
-// If there's a persistent store, make its specified changes
-try {
-	changes = JSON.parse(fs.readFileSync("persistent.json"));
-
-	for (var providerName in changes) {
-		var change = changes[providerName];
-		if (typeof change == "object") {
-			// table row
-			for (var rowIndex in change) {
-				mib.addTableRow(providerName, change[rowIndex]);
-			}
-		} else {
-			mib.setScalarValue(providerName, change);
-		}
-	}
-} catch (e) {
-	console.log("Could not parse persistent storage");
-	changes = {};
-}
-
 mib.dump ({
 	leavesOnly: true,
     showProviders: true,

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -197,6 +197,12 @@ mib.setTableRowDefaultValues(
     undefined          // rsuWsaStatus           RowStatus
   ]);
 
+mib.addTableRow("rsuWsaServiceEntry", [ 1, 4, 1 ]);
+console.log("Row: ", JSON.stringify(mib.getTableRowCells("rsuWsaServiceEntry", [1])));
+mib.deleteTableRow("rsuWsaServiceEntry", [ 1 ] );
+mib.addTableRow("rsuWsaServiceEntry", [ 1, 4, 1 ]);
+console.log("Row: ", JSON.stringify(mib.getTableRowCells("rsuWsaServiceEntry", [1])));
+
 var changes;
 
 /*

--- a/example/snmp-agent.js
+++ b/example/snmp-agent.js
@@ -82,7 +82,8 @@ var tableProvider = {
             number: 2,
             name: "ifDescr",
             type: snmp.ObjectType.OctetString,
-            maxAccess: snmp.MaxAccess['read-write']
+			maxAccess: snmp.MaxAccess['read-write'],
+			defVal: "Hello world!"
         },
         {
             number: 3,
@@ -119,6 +120,7 @@ var tableProvider = {
 };
 agent.registerProvider (tableProvider);
 
+/*
 agent.setScalarReadCreateHandler(
 	(provider) => {
 		// If there's a default value specified...
@@ -152,7 +154,6 @@ agent.setScalarReadCreateHandler(
     }
 );
 
-
 agent.setTableRowStatusHandler(
 	(provider, action, row) => {
 		const tc = provider.tableColumns;
@@ -167,21 +168,22 @@ agent.setTableRowStatusHandler(
 		}
 
 		switch (provider.name) {
-            case "ifTable" :
-                return (
-                    [
-                        Array.isArray(row) ? row[0] : row,
-                        defVal(1, "Hello world!"),
-                        defVal(2, 24),
-                        (action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"])
-                    ]
-                );
+			case "ifTable" :
+				return (
+					[
+						Array.isArray(row) ? row[0] : row,
+						"Hi there",
+						defVal(2, 24),
+						(action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"])
+					]
+				);
 
-            default :
-                return undefined;
-        }
-    }
+			default :
+				return undefined;
+		}
+	}
 );
+*/
 
 var mib = agent.getMib ();
 mib.setScalarValue ("sysDescr", "Rage inside the machine!");
@@ -198,7 +200,7 @@ mib.addTableRow ("ifTable", [2, "eth0", 6, 2]);
 //console.log (JSON.stringify (providers, null, 2));
 
 mib.dump ({
-    leavesOnly: true,
+	leavesOnly: true,
     showProviders: true,
     showValues: true,
     showTypes: true

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ var AgentEvent = {
 
     // successful action events
     0: "autoCreateScalar",
-    1: "tableRowCreated",
+    1: "autoCreateTableRow",
     2: "tableRowDeleted",
     3: "getEndOfMibView",
     4: "get",
@@ -4300,7 +4300,7 @@ var Agent = function (options, callback, mib) {
 	this.context = "";
 	this.forwarder = new Forwarder (this.listener, this.callback);
 
-	this.on("agentAction", (event) => {
+	this.on("agentEvent", (event) => {
 		if (this.agentEventHandler) {
 			this.agentEventHandler(event);
 		}
@@ -4478,7 +4478,7 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 				value = this.castSetValue ( provider.scalarType, value );
 				this.mib.setScalarValue ( provider.name, value );
 
-				this.emit ("agentAction",	{
+				this.emit ("agentEvent",	{
 					eventType: "autoCreateScalar",
 					oid: oid,
 					providerName: provider.name,
@@ -4540,7 +4540,7 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 					// Add the table row
 					this.mib.addTableRow ( provider.name, value );
 
-					this.emit ("agentAction",	{
+					this.emit ("agentEvent",	{
 						eventType: "autoCreateTableRow",
 						oid: oid,
 						providerName: provider.name,
@@ -4642,7 +4642,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					value: null
 				});
 
-				me.emit ("agentAction",  {
+				me.emit ("agentEvent",  {
 					eventType: "ERRnoInstance",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4665,7 +4665,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					});
 				};
 
-				me.emit ("agentAction",  {
+				me.emit ("agentEvent",  {
 					eventType: "ERRnoProvider",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4686,7 +4686,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					});
 				};
 
-				me.emit ("agentAction",  {
+				me.emit ("agentEvent",  {
 					eventType: "ERRnoAccess",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4780,7 +4780,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						});
 						handlers[i] = getIcsHandler;
 
-						me.emit ("agentAction",  {
+						me.emit ("agentEvent",  {
 							eventType: "ERRbadRowStatusAction",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,
@@ -4846,9 +4846,8 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							// Delete the table row
 							me.mib.deleteTableRow ( name, row );
 
-							me.emit ("agentAction",  {
+							me.emit ("agentEvent",  {
 								eventType: "tableRowDeleted",
-								requestType: PduType[requestPdu.type],
 								oid: requestPdu.varbinds[i].oid,
 								providerName: name,
 								row: row
@@ -4867,9 +4866,8 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							// No special handling required. Just save the new value.
 							mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
 
-							me.emit ("agentAction",  {
+							me.emit ("agentEvent",  {
 								eventType: "set",
-								requestType: PduType[requestPdu.type],
 								oid: requestPdu.varbinds[i].oid,
 								providerName: providerNode.provider.name,
 								value: requestPdu.varbinds[savedIndex].value
@@ -4880,7 +4878,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							requestPdu.varbinds[savedIndex].type == ObjectType.EndOfMibView ) {
 						responseVarbindType = ObjectType.EndOfMibView;
 
-						me.emit ("agentAction",  {
+						me.emit ("agentEvent",  {
 							eventType: "getEndOfMibView",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,
@@ -4890,7 +4888,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					} else {
 						responseVarbindType = mibRequests[savedIndex].instanceNode.valueType;
 
-						me.emit ("agentAction",  {
+						me.emit ("agentEvent",  {
 							eventType: "get",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,

--- a/index.js
+++ b/index.js
@@ -4855,7 +4855,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 
 							me.emit ("agentEvent",  {
 								eventType: "tableRowDeleted",
-								oid: requestPdu.varbinds[i].oid,
+								oid: requestPdu.varbinds[savedIndex].oid,
 								providerName: name,
 								row: row
 							});
@@ -4874,7 +4874,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
 
 							if ( provider.type == MibProviderType.Table ) {
-								subOid = Mib.getSubOidFromBaseOid (requestPdu.varbinds[i].oid, provider.oid);
+								subOid = Mib.getSubOidFromBaseOid (requestPdu.varbinds[savedIndex].oid, provider.oid);
 								subAddr = subOid.split(".");
 								column = parseInt(subAddr.shift(), 10);
 								column = provider.tableColumns.findIndex(entry => entry.number === column);
@@ -4890,7 +4890,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 
 							me.emit ("agentEvent",  Object.assign({
 								eventType: "set",
-								oid: requestPdu.varbinds[i].oid,
+								oid: requestPdu.varbinds[savedIndex].oid,
 								providerName: providerNode.provider.name,
 								value: requestPdu.varbinds[savedIndex].value
 							}, tableInfo));
@@ -4903,7 +4903,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						me.emit ("agentEvent",  {
 							eventType: "getEndOfMibView",
 							requestType: PduType[requestPdu.type],
-							oid: requestPdu.varbinds[i].oid,
+							oid: requestPdu.varbinds[savedIndex].oid,
 							providerName: providerNode.provider.name,
 							value: mibRequests[savedIndex].instanceNode.value
 						});
@@ -4913,7 +4913,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						me.emit ("agentEvent",  {
 							eventType: "get",
 							requestType: PduType[requestPdu.type],
-							oid: requestPdu.varbinds[i].oid,
+							oid: requestPdu.varbinds[savedIndex].oid,
 							providerName: providerNode.provider.name,
 							value: mibRequests[savedIndex].instanceNode.value
 						});

--- a/index.js
+++ b/index.js
@@ -4317,7 +4317,7 @@ var Agent = function (options, callback, mib) {
 	this.forwarder = new Forwarder (this.listener, this.callback);
 	this.agentEventEmitter = new events.EventEmitter(); // local emitter
 	AGENT_EVENT_METHOD =
-		options.agentEventMethod
+		"agentEventMethod" in options
 			? options.agentEventMethod
 			: AgentEventMethod.separateCallback | AgentEventMethod.individual;
 

--- a/index.js
+++ b/index.js
@@ -4378,9 +4378,9 @@ Agent.prototype.tableRowStatusHandlerInternal = function (provider, action, row)
 				// It's an index column. Use the next index value
 				values.push(rowIndexValues.shift());
 			} else if ( columnInfo.rowStatus ) {
-				// It's the RowStatus column. Replace the action with the appropriate state
-				values.push( action == "createAndGo" ? RowStatus["active"] : RowStatus["notInService"] );
-			} else if ( "defVal" in tc[index] ) {
+				// It's the RowStatus column. Retain the action value for now; replaced later
+				values.push( RowStatus[action] );
+			} else if ( "defVal" in columnInfo ) {
 				// Neither index nor RowStatus column, so use the default value
 				values.push( columnInfo.defVal );
 			} else {

--- a/index.js
+++ b/index.js
@@ -3942,7 +3942,7 @@ Mib.prototype.getTableRowInstanceFromRow = function (provider, row) {
 	return rowIndex;
 };
 
-function getRowIndexFromOid (oid, index) {
+Mib.getRowIndexFromOid = function (oid, index) {
 	var addressRemaining = oid.split (".");
 	var length = 0;
 	var values = [];
@@ -3979,8 +3979,6 @@ function getRowIndexFromOid (oid, index) {
 	}
 	return values;
 }
-
-Mib.prototype.getRowIndexFromOid = getRowIndexFromOid;
 
 Mib.prototype.getTableRowInstanceFromRowIndex = function (provider, rowIndex) {
 	var rowIndexOid = [];
@@ -4047,7 +4045,7 @@ Mib.prototype.getTableColumnCells = function (table, columnNumber, includeInstan
 
 	for ( var instanceNode of instanceNodes ) {
 		instanceOid = Mib.getSubOidFromBaseOid (instanceNode.oid, columnNode.oid);
-		indexValues.push (this.getRowIndexFromOid (instanceOid, providerIndex));
+		indexValues.push (Mib.getRowIndexFromOid (instanceOid, providerIndex));
 		columnValues.push (instanceNode.value);
 	}
 	if ( includeInstances ) {
@@ -4522,7 +4520,7 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 			subOid = Mib.getSubOidFromBaseOid (oid, provider.oid);
 			subAddr = subOid.split(".");
 			column = parseInt(subAddr.shift(), 10);
-			row = getRowIndexFromOid(subAddr.join("."), provider.tableIndex);
+			row = Mib.getRowIndexFromOid(subAddr.join("."), provider.tableIndex);
 			rowStatusColumn = provider.tableColumns.reduce( (acc, current) => current.rowStatus ? current.number : acc, null );
 
 			if ( requestType === PduType.SetRequest &&
@@ -4800,7 +4798,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							var subAddr = subOid.split(".");
 
 							subAddr.shift(); // shift off the column number, leaving the row index values
-							row = getRowIndexFromOid( subAddr.join("."), provider.tableIndex );
+							row = Mib.getRowIndexFromOid( subAddr.join("."), provider.tableIndex );
 							name = provider.name;
 
 							// Delete the table row

--- a/index.js
+++ b/index.js
@@ -4803,6 +4803,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					errorIndex: i + 1
 				});
 			} else if ( requestPdu.type === PduType.SetRequest &&
+					providerNode.provider.type == MibProviderType.Table &&
 					typeof (rowStatusColumn = providerNode.provider.tableColumns.reduce(
 								(acc, current) => current.rowStatus ? current.number : acc, null )) == "number" &&
 					instanceNode.getTableColumnFromInstanceNode() === rowStatusColumn) {
@@ -4943,8 +4944,9 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						provider = providerNode.provider;
 
 						// Is this a RowStatus column with a value of 6 (delete)?
-						rowStatusColumn = provider.tableColumns.reduce(
-							(acc, current) => current.rowStatus ? current.number : acc, null );
+						rowStatusColumn = provider.type == MibProviderType.Table
+							? provider.tableColumns.reduce( (acc, current) => current.rowStatus ? current.number : acc, null )
+							: null;
 						if ( requestPdu.varbinds[savedIndex].value === RowStatus["destroy"] &&
 							typeof rowStatusColumn == "number" &&
 							column === rowStatusColumn ) {

--- a/index.js
+++ b/index.js
@@ -3978,7 +3978,7 @@ Mib.getRowIndexFromOid = function (oid, index) {
 		}
 	}
 	return values;
-}
+};
 
 Mib.prototype.getTableRowInstanceFromRowIndex = function (provider, rowIndex) {
 	var rowIndexOid = [];

--- a/index.js
+++ b/index.js
@@ -4299,7 +4299,8 @@ var Agent = function (options, callback, mib) {
 	this.mib = mib || new Mib ();
 	this.context = "";
 	this.forwarder = new Forwarder (this.listener, this.callback);
-	this.on("agentRequest", (event) => {
+
+	this.on("agentAction", (event) => {
 		if (this.agentEventHandler) {
 			this.agentEventHandler(event);
 		}
@@ -4477,7 +4478,7 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 				value = this.castSetValue ( provider.scalarType, value );
 				this.mib.setScalarValue ( provider.name, value );
 
-				this.emit ("agentRequest",	{
+				this.emit ("agentAction",	{
 					eventType: "autoCreateScalar",
 					oid: oid,
 					providerName: provider.name,
@@ -4539,8 +4540,8 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 					// Add the table row
 					this.mib.addTableRow ( provider.name, value );
 
-					this.emit ("agentRequest",	{
-						eventType: "tableRowCreated",
+					this.emit ("agentAction",	{
+						eventType: "autoCreateTableRow",
 						oid: oid,
 						providerName: provider.name,
 						values: value
@@ -4641,7 +4642,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					value: null
 				});
 
-				me.emit ("agentRequest",  {
+				me.emit ("agentAction",  {
 					eventType: "ERRnoInstance",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4664,7 +4665,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					});
 				};
 
-				me.emit ("agentRequest",  {
+				me.emit ("agentAction",  {
 					eventType: "ERRnoProvider",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4685,7 +4686,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					});
 				};
 
-				me.emit ("agentRequest",  {
+				me.emit ("agentAction",  {
 					eventType: "ERRnoAccess",
 					requestType: PduType[requestPdu.type],
 					oid: requestPdu.varbinds[i].oid,
@@ -4779,7 +4780,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						});
 						handlers[i] = getIcsHandler;
 
-						me.emit ("agentRequest",  {
+						me.emit ("agentAction",  {
 							eventType: "ERRbadRowStatusAction",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,
@@ -4819,8 +4820,6 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 						type: error.type || ObjectType.Null,
 						value: error.value || null
 					};
-
-					// appNotifies is already updated for errors; nothing more to do here
 				} else {
 					if ( requestPdu.type == PduType.SetRequest ) {
 						var column = instanceNode.getTableColumnFromInstanceNode();
@@ -4847,7 +4846,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							// Delete the table row
 							me.mib.deleteTableRow ( name, row );
 
-							me.emit ("agentRequest",  {
+							me.emit ("agentAction",  {
 								eventType: "tableRowDeleted",
 								requestType: PduType[requestPdu.type],
 								oid: requestPdu.varbinds[i].oid,
@@ -4868,7 +4867,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							// No special handling required. Just save the new value.
 							mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
 
-							me.emit ("agentRequest",  {
+							me.emit ("agentAction",  {
 								eventType: "set",
 								requestType: PduType[requestPdu.type],
 								oid: requestPdu.varbinds[i].oid,
@@ -4881,7 +4880,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							requestPdu.varbinds[savedIndex].type == ObjectType.EndOfMibView ) {
 						responseVarbindType = ObjectType.EndOfMibView;
 
-						me.emit ("agentRequest",  {
+						me.emit ("agentAction",  {
 							eventType: "getEndOfMibView",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,
@@ -4891,7 +4890,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 					} else {
 						responseVarbindType = mibRequests[savedIndex].instanceNode.valueType;
 
-						me.emit ("agentRequest",  {
+						me.emit ("agentAction",  {
 							eventType: "get",
 							requestType: PduType[requestPdu.type],
 							oid: requestPdu.varbinds[i].oid,

--- a/index.js
+++ b/index.js
@@ -4530,9 +4530,9 @@ Agent.prototype.tryCreateInstance = function (varbind, requestType) {
 				if ( (varbind.value === RowStatus["createAndGo"] || varbind.value === RowStatus["createAndWait"]) && 
 						provider.createHandler !== null ) {
 
-					// The registered tableRowStatusHandler will
-					// return an array containing all table column
-					// values for the table row to be added.
+					// The create handler will return an array
+					// containing all table column values for the
+					// table row to be added.
 					value = ( provider.createHandler || this.tableRowStatusHandlerInternal )( provider, RowStatus[varbind.value], row );
 					if ( typeof value == "undefined") {
 						// Handler said do not create instance

--- a/index.js
+++ b/index.js
@@ -4813,7 +4813,7 @@ Agent.prototype.request = function (requestMessage, rinfo) {
             var subAddr;
             var row;
             var column;
-		    var name;
+			var name;
             var provider;
             var tableInfo;
 			var responseVarbind;
@@ -4873,12 +4873,12 @@ Agent.prototype.request = function (requestMessage, rinfo) {
 							// No special handling required. Just save the new value.
 							mibRequests[savedIndex].instanceNode.setValue (requestPdu.varbinds[savedIndex].value);
 
-                            if ( provider.type == MibProviderType.Table ) {
-			                    subOid = Mib.getSubOidFromBaseOid (requestPdu.varbinds[i].oid, provider.oid);
-			                    subAddr = subOid.split(".");
-                                column = parseInt(subAddr.shift(), 10);
-			                    column = provider.tableColumns.findIndex(entry => entry.number === column);
-			                    row = getRowIndexFromOid(subAddr.join("."), provider.tableIndex);
+							if ( provider.type == MibProviderType.Table ) {
+								subOid = Mib.getSubOidFromBaseOid (requestPdu.varbinds[i].oid, provider.oid);
+								subAddr = subOid.split(".");
+								column = parseInt(subAddr.shift(), 10);
+								column = provider.tableColumns.findIndex(entry => entry.number === column);
+								row = getRowIndexFromOid(subAddr.join("."), provider.tableIndex);
 
                                 tableInfo = {
                                     row: row,

--- a/index.js
+++ b/index.js
@@ -4301,7 +4301,7 @@ var Agent = function (options, callback, mib) {
 	this.forwarder = new Forwarder (this.listener, this.callback);
 	this.on("agentRequest", (event) => {
 		if (this.agentEventHandler) {
-		  this.agentEventHandler(event);
+			this.agentEventHandler(event);
 		}
 	});
 };

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -392,8 +392,13 @@ var MIB = function (dir) {
                                                         c1++;
                                                         val += Symbols[c1];
                                                     }
-                                                    //build value array.
-                                                    val = val.replace("{", "").replace("}", "").split(",");
+                                                    if ( key == 'DEFVAL' ) {
+                                                        // DEFVAL { 1500 } is not an array
+                                                        val = val.replace(/^{/,'').replace(/}$/,'').trim();
+                                                    } else {
+                                                        // build value array
+                                                        val = val.replace("{", "").replace("}", "").split(",");
+                                                    }
                                                 }
                                                
                                                 switch (key) {

--- a/lib/mib.js
+++ b/lib/mib.js
@@ -394,7 +394,7 @@ var MIB = function (dir) {
                                                     }
                                                     if ( key == 'DEFVAL' ) {
                                                         // DEFVAL { 1500 } is not an array
-                                                        val = val.replace(/^{/,'').replace(/}$/,'').trim();
+                                                        val = val.replace(/^{/, '').replace(/}$/, '').trim();
                                                     } else {
                                                         // build value array
                                                         val = val.replace("{", "").replace("}", "").split(",");


### PR DESCRIPTION
Using RowStatus to add and delete rows, in some scenarios, add, delete, add fails. I have provided here a demo that reproduces the problem.

- Run this code, e.g.: `node example/snmp-agent.js -p 1611`
- Add a row, delete the row, try to re-add it again:
  - `snmpset -v2c -c private localhost:1611 1.0.15628.4.1.13.1.8.1 i 4`
  - `snmpset -v2c -c private localhost:1611 1.0.15628.4.1.13.1.8.1 i 6`
  - `snmpset -v2c -c private localhost:1611 1.0.15628.4.1.13.1.8.1 i 4`

The final add will fail. It's failing because `tryCreateInstance`
created the row, but `this.mib.lookup (oid);` at the end of
`tryCreateInstance` then fails (quite unexpectedly).