### PR TITLE
Response invalid code

### DIFF
--- a/index.js
+++ b/index.js
@@ -276,10 +276,11 @@ _expandConstantObject (ResponseInvalidCode);
  ** Exception class definitions
  **/
 
-function ResponseInvalidError (message, code) {
+function ResponseInvalidError (message, code, info) {
 	this.name = "ResponseInvalidError";
 	this.message = message;
 	this.code = code;
+	this.info = info;
 	Error.captureStackTrace(this, ResponseInvalidError);
 }
 util.inherits (ResponseInvalidError, Error);
@@ -1525,7 +1526,7 @@ Message.prototype.checkAuthentication = function (user, responseCb) {
 				+ " received in message does not match digest "
 				+ Authentication.calculateDigest (this.buffer, user.authProtocol, user.authKey,
 					this.msgSecurityParameters.msgAuthoritativeEngineID).toString ('hex')
-				+ " calculated for message"), ResponseInvalidCode.EAuthFailure );
+				+ " calculated for message", ResponseInvalidCode.EAuthFailure, { user }));
 		return false;
 	}
 


### PR DESCRIPTION
`ResponseInvalidError` is passed to the user's callback. It is difficult and unreliable, however, to parse English text error messages, particularly when they are dynamically generated (not static) strings, and in any case, there's no guarantee that the strings won't change in the future for arbitrary reasons.

To remedy this situation, I have created `ResponseInvalidCode` values which are passed to the `ResponseInvalidError` constructor, so that when the callback receives the error, it can look at the code rather than the text string. Additionally, there is an optional `info` parameter to that constructor, to provide additional information to the user. In my case, I am required to send an SNMPv3 inform whenever there is an authentication error, so I need the details of the user provided in the request. (At present, there are no other uses of the `info` parameter, but upon user need, it is available for subsequent enhancements.)