### PR TITLE
Fix SEQUENCE OF in getProvidersForModule

### DIFF
--- a/index.js
+++ b/index.js
@@ -3228,7 +3228,7 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 			if ( syntax.startsWith ("SEQUENCE OF") ) {
 				// start of table
 				currentTableProvider = {
-					tableName: mibEntry.ObjectName,
+					name: mibEntry.ObjectName,
 					type: MibProviderType.Table,
 					//oid: mibEntry.OID,
 					tableColumns: [],
@@ -3261,9 +3261,9 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 						// unexpected
 					} else {
 						parentOid = mibEntry["OBJECT IDENTIFIER"].split (" ")[0];
-						if ( parentOid == currentTableProvider.tableName ) {
+						if ( parentOid == currentTableProvider.name ) {
 							// table entry
-							currentTableProvider.name = mibEntry.ObjectName;
+							currentTableProvider.entryName = mibEntry.ObjectName;
 							currentTableProvider.oid = mibEntry.OID;
 							if ( mibEntry.INDEX ) {
 								currentTableProvider.tableIndex = [];
@@ -3292,7 +3292,7 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 								currentTableProvider.tableAugments = mibEntry.AUGMENTS[0].trim();
 								currentTableProvider.tableIndex = null;
 							}
-						} else if ( parentOid == currentTableProvider.name ) {
+						} else if ( parentOid == currentTableProvider.entryName ) {
 							// table column
 							var columnDefinition = {
 								number: parseInt (mibEntry["OBJECT IDENTIFIER"].split (" ")[1]),


### PR DESCRIPTION

Here is a part of my MIB. It contains an object called tempSensors with is a SEQUENCE OF TempSensorEntry:
```
TempSensorIndex ::= TEXTUAL-CONVENTION
	STATUS  current
	DESCRIPTION
		"A unique value, greater than zero, for each temp sensor in the managed system."
	SYNTAX Unsigned32
	
	
tempSensors OBJECT-TYPE
	SYNTAX  SEQUENCE OF TempSensorEntry
	MAX-ACCESS not-accessible
	STATUS  current
	DESCRIPTION
		"A list of temp sensor entries."
	::= { tricontrol 3 }
    
              
tempSensorEntry OBJECT-TYPE
	SYNTAX  TempSensorEntry
	MAX-ACCESS not-accessible
	STATUS current
	DESCRIPTION
		"An entry containing information applicable to a particular temp sensor."
	INDEX { tempSensorId }
	::= { tempSensors 1 } 

	        
TempSensorEntry ::= SEQUENCE {
	tempSensorId			TempSensorIndex,			
	tempSensorValue			Integer32,
    tempSensorIsEnabled		TruthValue,
    tempSensorIsWorking		TruthValue
}

           
tempSensorId OBJECT-TYPE
	SYNTAX  TempSensorIndex
	MAX-ACCESS read-only
	STATUS  current
	DESCRIPTION
		"Temp sensor ID."
	::= { tempSensorEntry 1 }                              
                      
                                     
tempSensorValue OBJECT-TYPE
	SYNTAX  Integer32
	MAX-ACCESS read-only
	STATUS  current
	DESCRIPTION
		"Current temperature measured by temp sensor."
	::= { tempSensorEntry 2 }          

tempSensorIsEnabled OBJECT-TYPE
	SYNTAX  TruthValue
	MAX-ACCESS read-only
	STATUS  current
	DESCRIPTION
		"Indicates if temp sensor is enabled or not."
	::= { tempSensorEntry 3 }  
	
tempSensorIsWorking OBJECT-TYPE
	SYNTAX  TruthValue
	MAX-ACCESS read-only
	STATUS  current
	DESCRIPTION
		"Indicates if sensor is working or not."
	::= { tempSensorEntry 4 }  `
```

Here is a part of my code:

	this.snmp.store.loadFromFile(path.join(__dirname, 'TSAB-TRICONTROL-MIB.my'));
	let mib = this.snmp.agent.getMib();
	console.log(util.inspect(this.snmp.store.getProvidersForModule("TSAB-TRICONTROL-MIB"), { showHidden: true, depth: null }));
	mib.registerProviders(this.snmp.store.getProvidersForModule("TSAB-TRICONTROL-MIB"));
	mib.addTableRow ("tempSensors", [1, -100, -100, -100]);

Running it generates the following error:

UnhandledPromiseRejectionWarning: ReferenceError: No MIB provider registered for tempSensors
    at Mib.getProviderNodeForTable (K:\temp\netsnmp\node-net-snmp\index.js:4033:9)
    at Mib.addTableRow (K:\temp\netsnmp\node-net-snmp\index.js:4157:22)

The console.log shows:

	{ 
		tableName: 'tempSensors',
		type: 2,
		tableColumns: [ 
			{ number: 1, name: 'tempSensorId', type: 66, maxAccess: 2 },
			{ number: 2, name: 'tempSensorValue', type: 2, maxAccess: 2 },
			{ number: 3, name: 'tempSensorIsEnabled', type: 2, maxAccess: 2 },
			{ number: 4, name: 'tempSensorIsWorking', type: 2, maxAccess: 2 },
			[length]: 4 
		],
		tableIndex: [ 
			{ columnName: 'tempSensorId' }, 
			[length]: 1
		],
		maxAccess: 0,
		name: 'tempSensorEntry',											  
		oid: '1.3.6.1.4.1.22562.2.3.1' 
	}

With my changes in index.js the console.log shows as below, running the code above will not generating any error and the addTableRow actually does what its supposed to:
	
	{ 
		name: 'tempSensors',
		type: 2,
		tableColumns: [ 
			{ number: 1, name: 'tempSensorId', type: 66, maxAccess: 2 },
			{ number: 2, name: 'tempSensorValue', type: 2, maxAccess: 2 },
			{ number: 3, name: 'tempSensorIsEnabled', type: 2, maxAccess: 2 },
			{ number: 4, name: 'tempSensorIsWorking', type: 2, maxAccess: 2 },
			[length]: 4 
		],
		tableIndex: [ 
			{ columnName: 'tempSensorId' }, 
			[length]: 1
		],
		maxAccess: 0,
	    entryName: 'tempSensorEntry',											  
		oid: '1.3.6.1.4.1.22562.2.3.1' 
	}
	