### PR TITLE
getOidAddressFromValue: allow value to be buffer too, not just string

### DIFF
--- a/index.js
+++ b/index.js
@@ -4081,7 +4081,13 @@ Mib.prototype.getOidAddressFromValue = function (value, indexPart) {
 			oidComponents = value.split (".");
 			break;
 		case ObjectType.OctetString:
-			oidComponents = [...value].map (c => c.charCodeAt());
+			if ( value instanceof Buffer ) {
+				// Buffer
+				oidComponents = Array.prototype.slice.call (value);
+			} else {
+				// string
+				oidComponents = [...value].map (c => c.charCodeAt());
+			}
 			break;
 		case ObjectType.IpAddress:
 			return value.split (".");


### PR DESCRIPTION
This seems to do the trick, re: #175. 

Would please look at the code immediately after this, though, to confirm it's correct? It's prepending a length, which seems reasonable, but `snmpwalk` then doesn't parse it as I'd expect. Is that length always supposed to be prepended?

For example, 
```
...
IPV6-MIB::ipv6IfStatsOutMcastPkts.13 = Counter32: 54701
IPV6-MIB::ipv6IfStatsOutMcastPkts.14 = Counter32: 54701
IPV6-MIB::ipv6IfStatsOutMcastPkts.15 = Counter32: 117308
IPV6-MIB::ipv6AddrPfxLength.1.'..........BN...J'.168 = INTEGER: 64 bits
IPV6-MIB::ipv6AddrPfxLength.2.'.....#B.........'.1 = INTEGER: 64 bits
IPV6-MIB::ipv6AddrPfxLength.2.'................'.1 = INTEGER: 64 bits
IPV6-MIB::ipv6AddrPfxLength.2.'..........B....O'.169 = INTEGER: 64 bits
...
```
Each of the PfxLength OIDs has a low-number IfIndex (1, 2, 2, and 2 here) followed by a 16-byte binary address. The `168` at the end of the first one is the final octet of the address, but is pushed off the end and displayed separately because the length is prepended (16, shown as the first dot in the addrss since 16 is a control character). It appears to me that if `snmpwalk` knows properly how to parse and display based on the MIB, that maybe that length shouldn't be there??? (Of course, it's also possible that I'm reading too much into `snmpwalk`'s ability to parse and display.)

