### PR TITLE
Fixup getNext when called for a non-node

### DIFF
--- a/index.js
+++ b/index.js
@@ -3492,7 +3492,7 @@ MibNode.prototype.findChildImmediatelyBefore = function (index) {
 			}
 		}
 	}
-	return this.children[sortedChildrenKeys[sortedChildrenKeys.length]];
+	return this.children[sortedChildrenKeys[sortedChildrenKeys.length - 1]];
 };
 
 MibNode.prototype.isDescendant = function (address) {
@@ -3824,7 +3824,16 @@ Mib.prototype.getTreeNode = function (oid) {
 		var last = address.pop ();
 		var parent = this.lookupAddress (address);
 		if ( parent ) {
-			return (parent.findChildImmediatelyBefore (last) || parent);
+			node = parent.findChildImmediatelyBefore (last);
+			if ( !node )
+				return parent;
+			while ( true ) {
+				// Find the last descendant
+				var childrenAddresses = Object.keys (node.children).sort ( (a, b) => a - b);
+				if ( childrenAddresses.length == 0 )
+					return node;
+				node = node.children[childrenAddresses[childrenAddresses.length - 1]];
+			}
 		}
 	}
 	return this.root;


### PR DESCRIPTION
GetNext should always return a value that is >= start oid, but this is not always the case.

E g, if a tree has nodes nnn.2.2 and nnn.2.4 (with values at nnn.2.2.0 and nnn.2.4.0),
but not nnn.2.3, and nnn.2.3 is requested, GetNext will return 2.2.0 instead of the expected 2.4.0.
The proposed code fixes that case by letting Mib.getTextNode return the last descendant.

getTreeNode is only used from Agent/Subagent.getNext, and the relevant code path is executed only if
the node suggested is not in the tree, so changing getTreeNode seems safe enough.