### PR TITLE
Fix logic for v3 time syncronization needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -2211,7 +2211,7 @@ Session.prototype.onMsg = function (buffer) {
 				return;
 			}
 			req.originalPdu.contextName = this.context;
-			var timeSyncNeeded = ! message.msgSecurityParameters.msgAuthoritativeEngineBoots || ! message.msgSecurityParameters.msgAuthoritativeEngineTime;
+			var timeSyncNeeded = ! message.msgSecurityParameters.msgAuthoritativeEngineBoots && ! message.msgSecurityParameters.msgAuthoritativeEngineTime;
 			this.sendV3Req (req.originalPdu, req.feedCb, req.responseCb, req.options, req.port, timeSyncNeeded);
 		}
 	} else if ( this.proxy ) {


### PR DESCRIPTION
Changes the time sync check from
`! snmpEngineBoots || ! snmpEngineTime`

which seems to be incorrectly require time sync from devices reporting an engine uptime but zero engine boots, to
`! snmpEngineBoots && ! snmpEngineTime`
