### PR TITLE
Implement SHA2, fix DES, and some crypto-related cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,16 @@ RFC 3414:
 
 This object contains constants to select a supported digest algorithm for SNMPv3
 messages that require authentication:
- * `md5` - for MD5 message authentication (HMAC-MD5-96)
- * `sha` - for SHA message authentication (HMAC-SHA-96)
+ * `md5` - for HMAC-MD5 message authentication
+ * `sha` - for HMAC-SHA-1 message authentication
+ * `sha224` - for HMAC-SHA-224 message authentication
+ * `sha256` - for HMAC-SHA-256 message authentication
+ * `sha384` - for HMAC-SHA-384 message authentication
+ * `sha512` - for HMAC-SHA-512 message authentication
 
-These are the two hash algorithms specified in RFC 3414.  Other digest algorithms
-are not supported.
+MD5 and SHA (actually SHA-1) are the hash algorithms specified in the original
+SNMPv3 User-Based Security Model RFC (RFC 3414); the other four were added later
+in RFC 7860.
 
 ## snmp.PrivProtocols
 

--- a/index.js
+++ b/index.js
@@ -1361,39 +1361,38 @@ Message.prototype.toBufferV3 = function () {
 	writer.endSequence ();
 
 	// msgSecurityParameters
-	var msgSecurityParametersWriter = new ber.Writer ();
-	msgSecurityParametersWriter.startSequence ();
-	//msgSecurityParametersWriter.writeString (this.msgSecurityParameters.msgAuthoritativeEngineID);
+	writer.startSequence (ber.OctetString);
+	writer.startSequence ();
+	//writer.writeString (this.msgSecurityParameters.msgAuthoritativeEngineID);
 	// writing a zero-length buffer fails - should fix asn1-ber for this condition
 	if ( this.msgSecurityParameters.msgAuthoritativeEngineID.length == 0 ) {
-		msgSecurityParametersWriter.writeString ("");
+		writer.writeString ("");
 	} else {
-		msgSecurityParametersWriter.writeBuffer (this.msgSecurityParameters.msgAuthoritativeEngineID, ber.OctetString);
+		writer.writeBuffer (this.msgSecurityParameters.msgAuthoritativeEngineID, ber.OctetString);
 	}
-	msgSecurityParametersWriter.writeInt (this.msgSecurityParameters.msgAuthoritativeEngineBoots);
-	msgSecurityParametersWriter.writeInt (this.msgSecurityParameters.msgAuthoritativeEngineTime);
-	msgSecurityParametersWriter.writeString (this.msgSecurityParameters.msgUserName);
+	writer.writeInt (this.msgSecurityParameters.msgAuthoritativeEngineBoots);
+	writer.writeInt (this.msgSecurityParameters.msgAuthoritativeEngineTime);
+	writer.writeString (this.msgSecurityParameters.msgUserName);
 
 	if ( this.hasAuthentication() ) {
-		msgSecurityParametersWriter.writeBuffer (Authentication.AUTH_PARAMETERS_PLACEHOLDER, ber.OctetString);
+		writer.writeBuffer (Authentication.AUTH_PARAMETERS_PLACEHOLDER, ber.OctetString);
 	// should never happen where msgFlags has no authentication but authentication parameters still present
 	} else if ( this.msgSecurityParameters.msgAuthenticationParameters.length > 0 ) {
-		msgSecurityParametersWriter.writeBuffer (this.msgSecurityParameters.msgAuthenticationParameters, ber.OctetString);
+		writer.writeBuffer (this.msgSecurityParameters.msgAuthenticationParameters, ber.OctetString);
 	} else {
-		msgSecurityParametersWriter.writeString ("");
+		writer.writeString ("");
 	}
 
 	if ( this.hasPrivacy() ) {
-		msgSecurityParametersWriter.writeBuffer (encryptionResult.msgPrivacyParameters, ber.OctetString);
+		writer.writeBuffer (encryptionResult.msgPrivacyParameters, ber.OctetString);
 	// should never happen where msgFlags has no privacy but privacy parameters still present
 	} else if ( this.msgSecurityParameters.msgPrivacyParameters.length > 0 ) {
-		msgSecurityParametersWriter.writeBuffer (this.msgSecurityParameters.msgPrivacyParameters, ber.OctetString);
+		writer.writeBuffer (this.msgSecurityParameters.msgPrivacyParameters, ber.OctetString);
 	} else {
-		msgSecurityParametersWriter.writeString ("");
+		writer.writeString ("");
 	}
-	msgSecurityParametersWriter.endSequence ();
-
-	writer.writeBuffer (msgSecurityParametersWriter.buffer, ber.OctetString);
+	writer.endSequence ();
+	writer.endSequence ();
 
 	if ( this.hasPrivacy() ) {
 		writer.writeBuffer (encryptionResult.encryptedPdu, ber.OctetString);

--- a/index.js
+++ b/index.js
@@ -138,7 +138,11 @@ _expandConstantObject (SecurityLevel);
 var AuthProtocols = {
 	"1": "none",
 	"2": "md5",
-	"3": "sha"
+	"3": "sha",
+	"4": "sha224",
+	"5": "sha256",
+	"6": "sha384",
+	"7": "sha512"
 };
 
 _expandConstantObject (AuthProtocols);
@@ -931,6 +935,30 @@ Authentication.algorithms[AuthProtocols.sha] = {
 	KEY_LENGTH: 20,
 	AUTHENTICATION_CODE_LENGTH: 12,
 	CRYPTO_ALGORITHM: 'sha1'
+};
+
+Authentication.algorithms[AuthProtocols.sha224] = {
+	KEY_LENGTH: 28,
+	AUTHENTICATION_CODE_LENGTH: 16,
+	CRYPTO_ALGORITHM: 'sha224'
+};
+
+Authentication.algorithms[AuthProtocols.sha256] = {
+	KEY_LENGTH: 32,
+	AUTHENTICATION_CODE_LENGTH: 24,
+	CRYPTO_ALGORITHM: 'sha256'
+};
+
+Authentication.algorithms[AuthProtocols.sha384] = {
+	KEY_LENGTH: 48,
+	AUTHENTICATION_CODE_LENGTH: 32,
+	CRYPTO_ALGORITHM: 'sha384'
+};
+
+Authentication.algorithms[AuthProtocols.sha512] = {
+	KEY_LENGTH: 64,
+	AUTHENTICATION_CODE_LENGTH: 48,
+	CRYPTO_ALGORITHM: 'sha512'
 };
 
 Authentication.authToKeyCache = {};

--- a/index.js
+++ b/index.js
@@ -1376,18 +1376,12 @@ Message.prototype.toBufferV3 = function () {
 
 	if ( this.hasAuthentication() ) {
 		writer.writeBuffer (Authentication.AUTH_PARAMETERS_PLACEHOLDER, ber.OctetString);
-	// should never happen where msgFlags has no authentication but authentication parameters still present
-	} else if ( this.msgSecurityParameters.msgAuthenticationParameters.length > 0 ) {
-		writer.writeBuffer (this.msgSecurityParameters.msgAuthenticationParameters, ber.OctetString);
 	} else {
 		writer.writeString ("");
 	}
 
 	if ( this.hasPrivacy() ) {
 		writer.writeBuffer (encryptionResult.msgPrivacyParameters, ber.OctetString);
-	// should never happen where msgFlags has no privacy but privacy parameters still present
-	} else if ( this.msgSecurityParameters.msgPrivacyParameters.length > 0 ) {
-		writer.writeBuffer (this.msgSecurityParameters.msgPrivacyParameters, ber.OctetString);
 	} else {
 		writer.writeString ("");
 	}


### PR DESCRIPTION
This is a set of improvements to the SNMPv3 cryptography code, including

- Add support for the SHA2 family authentication protocols (sha224, sha256, sha384, sha512) specified in RFC 7860.
- Fix a data corruption issue in DES decryption due to inappropriate use of a padding removal feature.
