### PR TITLE
Rewrite getBulk's response handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Actions
 - `4 -  ECouldNotDecrypt`
 - `5 -  EAuthFailure`
 - `6 -  EReqResOidNoMatch`
-- `7 -  ENonRepeaterCountMismatch`
+- `7 -  (no longer used)
 - `8 -  EOutOfOrder`
 - `9 -  EVersionNoMatch`
 - `10 -  ECommunityNoMatch`


### PR DESCRIPTION
1. The ENonRepeaterCountMismatch error is eliminated since the conditions where it was generated correspond to perfectly valid responses that you're pretty much guaranteed to run into if you use multiple repeaters and a large enough maxRepetitions count.
2. backwardsGetNexts now properly prevents EOutOfOrder errors for all of the varbinds (previously it failed to do so for non-repeaters).
3. The OID ordering for repeaters is now checked properly if backwardsGetNexts is false.
4. The OID for error responses is now checked if reportOidMismatchErrors is true.