### PR TITLE
Fix writeUint

### DIFF
--- a/index.js
+++ b/index.js
@@ -520,9 +520,16 @@ function readVarbinds (buffer, varbinds) {
 }
 
 function writeUint (buffer, type, value) {
-	var b = Buffer.alloc (4);
-	b.writeUInt32BE (value, 0);
-	buffer.writeBuffer (b, type);
+	if (typeof(value) !== 'number')
+		throw new TypeError('argument must be a Number');
+	if (value >= 0x80000000) {
+		// asn1-ber's writeInt does not work correctly outside int32 range
+		let b = Buffer.alloc (5);
+		b.writeUInt32BE (value, 1);
+		buffer.writeBuffer (b, type);
+	} else {
+		buffer.writeInt (value, type);
+	}
 }
 
 function writeUint64 (buffer, value) {


### PR DESCRIPTION
ASN.1 BER encodes integers 0 .. 2**32-1 into 1 to 5 bytes:
```
00 .. 7f
00 80 .. 7f ff
00 80 00 .. 7f ff ff
00 80 00 00 .. 7f ff ff ff
00 80 00 00 00 .. 00 ff ff ff ff
```

The leading `00` byte is required when the second byte is `80..FF` since without it the integer would be parsed as being negative.

In contrast, writeUint was producing the encodings:
```
00 00 00 00 .. 00 7f ff ff   (redundant leading bytes)
00 80 00 00 .. 7f ff ff ff   (ok)
80 00 00 00 .. ff 7f ff ff   (wrong value)
ff 80 00 00 .. ff ff ff ff   (wrong value and redundant leading bytes)
```

Note that redundant leading bytes are not permitted and will cause a conforming ASN.1 BER parser to reject the data.