### PR TITLE
Fixed wrong value validation for IP Address type

### DIFF
--- a/index.js
+++ b/index.js
@@ -4603,7 +4603,8 @@ Agent.prototype.castSetValue = function ( type, value ) {
 
 		case ObjectType.IpAddress:
 			// A 32-bit internet address represented as OCTET STRING of length 4
-			if ( typeof value != "string" || value.length != 4 ) {
+			var bytes = value.split(".");
+			if ( typeof value != "string" || bytes.length != 4 ) {
 				throw new Error("Invalid IpAddress", value);
 			}
 			return value;


### PR DESCRIPTION
Fixed wrong value check in the castSetValue function, that caused an exception to be raised when sending a set request for a IPAddress variable.

Fixes #211 