### PR TITLE
Mib lexer: Split name followed by group into separate symbols

### DIFF
--- a/lib/mib.js
+++ b/lib/mib.js
@@ -167,14 +167,14 @@ var MIB = function (dir) {
                 case '(':
                     if ( ! this.CharBuffer.isComment && ! this.CharBuffer.isString ) {
                         this.CharBuffer.nested++;
-                        if ( char == '(') {
+                        if (char == '(' || char == '{') {
+                            // Emit the previous token if this is the start of an outer group
+                            if (this.CharBuffer.nested === 1)
+                                this.CharBuffer.Fill(FileName, row, column);
                             this.CharBuffer.inGroup++;
                         }
                     }
-                    if (this.CharBuffer.builder == 'INTEGER') {
-                        this.CharBuffer.Fill(FileName, row, column);
-                        this.CharBuffer.Append(char);
-                    } else if (this.CharBuffer.isComment || ((this.CharBuffer.isOID || this.CharBuffer.nested > 0) && (!this.CharBuffer.isList || this.CharBuffer.inGroup > 0))) {
+                    if (this.CharBuffer.isComment || ((this.CharBuffer.isOID || this.CharBuffer.nested > 0) && (!this.CharBuffer.isList || this.CharBuffer.inGroup > 0))) {
                         this.CharBuffer.Append(char);
                     } else {
                         this.CharBuffer.Fill(FileName, row, column);


### PR DESCRIPTION
This supports the valid syntax where a type constraint specified in parens or braces joins the type specifier with no whitespace in between. E.g., previously
```
   DisplayString(SIZE (2..10))
```
was parsed as a single symbol.  There was a special case for INTEGER, but this did not extend to Integer32 etc.  This patch generalizes the INTEGER case to tokenize upon seeing a '(' or '{' that open an outer group.