### PR TITLE
Fix string size constraints

### DIFF
--- a/index.js
+++ b/index.js
@@ -3392,7 +3392,7 @@ ModuleStore.getConstraintsFromSyntax = function (syntax) {
 			syntax = Object.keys(syntax)[0];
 		} else if ( firstSyntaxKey.sizes ) {
 			constraints = {
-				size: firstSyntaxKey.sizes
+				sizes: firstSyntaxKey.sizes
 			};
 			syntax = Object.keys(syntax)[0];
 		} else {
@@ -3553,7 +3553,7 @@ MibNode.prototype.setValue = function (newValue) {
 		}
 	} else if ( constraints.sizes ) {
 		// if size is constrained, value must have a length property
-		if ( ! ( "length" in newValue ) ) {
+		if ( newValue.length === undefined ) {
 			return false;
 		}
 		len = newValue.length;


### PR DESCRIPTION
Length constraints were not being applied when handling sets as the constraints object mistakenly used `size` rather than `sizes` which is what the applying code expects.

Also, at least in my latest node version, checking for `length` in a string threw an exception; so I changed it to an undefined check.