### PR TITLE
Support type constraints via textual conventions

### DIFF
--- a/lib/mib.js
+++ b/lib/mib.js
@@ -60,7 +60,7 @@ var MIB = function (dir) {
                 var R = this.RowIndex;
                 var C = this.ColumnIndex;
 
-                if (!this.Table[FileName][R]) {
+                if (!this.Table[FileName][R] || C === 0) {
                     this.Table[FileName][R] = Object.defineProperty([], "line", {
                         enumerable: false,
                         value: row + 1
@@ -143,11 +143,14 @@ var MIB = function (dir) {
             }
         },
         ParseLine: function (FileName, line, row) {
-            line = line + "\n";
-            for (var i = 0; i < line.length; i++) {
+            let len = line.length;
+            if (line[len - 1] === '\r')
+                --len;
+            for (var i = 0; i < len; i++) {
                 var char = line.charAt(i);
                 this.ParseChar(FileName, char, row, i);
             }
+            this.ParseChar(FileName, '\n', row, len);
         },
         ParseChar: function (FileName, char, row, column) {
             switch (char) {
@@ -309,7 +312,7 @@ var MIB = function (dir) {
                                 lastGoodDeclaration = row;
                                 break;
                             default:
-                                if (symbol.indexOf('--') == 0) {//REMOVE COMMENTS
+                                if (symbol.startsWith('--')) {//REMOVE COMMENTS
                                     //console.log(ModuleName, symbol);
                                     addSymbol = false;
                                 } else {
@@ -669,35 +672,36 @@ var MIB = function (dir) {
         },
         BuildObject: function (Object, ObjectName, macro, i, Symbols) {
 
-            var r = i;
-            var m = Symbols.indexOf('SYNTAX', r) - r;
-            var SYNTAX = Symbols[Symbols.indexOf('SYNTAX', r) + 1];
-            var val = Symbols[Symbols.indexOf('SYNTAX', r) + 2];
-            var c1 = Symbols.indexOf('SYNTAX', r) + 1;
+            var syntaxKeyword = Symbols.indexOf('SYNTAX', i);
+            var m = syntaxKeyword - i;
+            var c1 = syntaxKeyword + 1;
+            var SYNTAX = Symbols[c1];
+            var val = Symbols[c1 + 1];
 
             if (this.MACROS.indexOf(macro) > -1 && m < 10) {
-                switch (SYNTAX) {
-                    case "INTEGER":
-                        if (val.indexOf("{") == 0) {
-                            c1++;
-                            while (Symbols[c1].indexOf("}") == -1) {
-                                c1++;
-                                val += Symbols[c1].trim();
-                            }
-                            val = val.replace("{", "").replace("}", "").split(",");
+                if (val[0] === "{") {
+                    c1++;
+                    while (Symbols[c1].indexOf("}") == -1) {
+                        c1++;
+                        val += Symbols[c1].trim();
+                    }
+                    val = val.replace("{", "").replace("}", "").split(",");
 
-                            Object[ObjectName]['SYNTAX'] = {};
-                            Object[ObjectName]['SYNTAX'][SYNTAX] = {};
+                    Object[ObjectName]['SYNTAX'] = {};
+                    Object[ObjectName]['SYNTAX'][SYNTAX] = {};
 
-                            for (var TC = 0; TC < val.length; TC++) {
-                                Object[ObjectName]['SYNTAX'][SYNTAX][val[TC].split("(")[1].replace(")", "")] = val[TC].split("(")[0];
-                            }
-                        }
-                        break;
-                    default:
-                        Object[ObjectName]['SYNTAX'] = SYNTAX;
-                        break;
-
+                    for (var TC = 0; TC < val.length; TC++) {
+                        let openParenSplit = val[TC].split(/\s*\(\s*/);
+                        Object[ObjectName]['SYNTAX'][SYNTAX][openParenSplit[1].replace(/\s*\)\s*$/, '')] = openParenSplit[0].trimStart();
+                    }
+                }
+                else if (val[0] === '(') {
+                    const key = val.startsWith('(SIZE')? 'sizes' : 'ranges';
+                    Object[ObjectName]['SYNTAX'] = {};
+                    Object[ObjectName]['SYNTAX'][SYNTAX] = { [key]: this.GetRanges(val) };
+                }
+                else {
+                    Object[ObjectName]['SYNTAX'] = SYNTAX;
                 }
             }
         },


### PR DESCRIPTION
Read standard TCs from SNMPv2-TC and update MIB loader and constraint logic to support SYNTAX elements that reference `TEXTUAL-CONVENTION`s. Also support constraints derived from range `(N..M)` `(A..B | C..D | ...)` and size `(SIZE (N..M))` specifiers in `TEXTUAL-CONVENTION`s.