### PR TITLE
More tolerant parsing in `readUint32`

### DIFF
--- a/index.js
+++ b/index.js
@@ -392,6 +392,7 @@ function readUint32 (buffer) {
 	if ( ! Number.isInteger(parsedInt) ) {
 		throw new TypeError('Value read as integer ' + parsedInt + ' is not an integer');
 	}
+	parsedInt = (parsedInt>>>0);
 	if ( parsedInt < MIN_UNSIGNED_INT32 || parsedInt > MAX_UNSIGNED_INT32 ) {
 		throw new RangeError('Read integer ' + parsedInt + ' is outside the unsigned 32-bit range');
 	}

--- a/test/varbinds.js
+++ b/test/varbinds.js
@@ -1,43 +1,49 @@
-/* eslint-disable no-unused-expressions */
-
-var ber    = require ('asn1-ber').Ber;
-var assert = require('assert');
-var snmp   = require('../');
+const ber    = require ('asn1-ber').Ber;
+const assert = require('assert');
+const snmp   = require('../');
 
 describe('parseInt()', function() {
 	describe('given a negative integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(-3);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a negative integer', function() {
-			assert.equal(-3, snmp.ObjectParser.readInt(reader));
+			assert.equal(snmp.ObjectParser.readInt32(reader), -3);
 		});
-	}),
+	});
 	describe('given a positive integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(3245689);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(3245689, snmp.ObjectParser.readInt(reader));
+			assert.equal(snmp.ObjectParser.readInt32(reader), 3245689);
 		});
 	});
 });
 
 describe('parseUint()', function() {
 	describe('given a positive integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(3242425);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(3242425, snmp.ObjectParser.readUint(reader));
+			assert.equal(snmp.ObjectParser.readUint32(reader), 3242425);
 		});
-	}),
+	});
 	describe('given a negative integer', function() {
-		var writer = new ber.Writer();
+		const writer = new ber.Writer();
 		writer.writeInt(-3);
-		var reader = new ber.Reader(writer.buffer);
+		const reader = new ber.Reader(writer.buffer);
 		it('returns a positive integer', function() {
-			assert.equal(253, snmp.ObjectParser.readUint(reader));
+			assert.equal(snmp.ObjectParser.readUint32(reader), 4294967293);
+		});
+	});
+	describe('given a large integer', function() {
+		const writer = new ber.Writer();
+		writer.writeInt(4294967294);
+		const reader = new ber.Reader(writer.buffer);
+		it('returns a positive integer', function() {
+			assert.equal(snmp.ObjectParser.readUint32(reader), 4294967294);
 		});
 	});
 });


### PR DESCRIPTION
Reading uint 32 with missing leading byte required by
ASN.1 BER will add the leading byte.

closes #233