### PR TITLE
Add getTrapOIDsForModule function

### DIFF
--- a/index.js
+++ b/index.js
@@ -3148,6 +3148,44 @@ var ModuleStore = function () {
 	this.parser = mibparser ();
 };
 
+ModuleStore.prototype.getTrapOIDsForModule = function (moduleName) {
+	var mibModule = this.parser.Modules[moduleName];
+
+	var traps = [];
+	var mibEntry;
+	var syntaxTypes;
+	var entryArray;
+	var constraintsResults;
+	var constraints;
+
+	if ( ! mibModule ) {
+		throw new ReferenceError ("MIB module " + moduleName + " not loaded");
+	}
+	syntaxTypes = this.getSyntaxTypes ();
+	entryArray = Object.values (mibModule);
+	for ( var i = 0; i < entryArray.length ; i++ ) {
+		mibEntry = entryArray[i];
+		var syntax = mibEntry.SYNTAX;
+		var access = mibEntry["ACCESS"];
+		var maxAccess = (typeof mibEntry["MAX-ACCESS"] != "undefined" ? mibEntry["MAX-ACCESS"] : (access ? AccessToMaxAccess[access] : "not-accessible"));
+		var defVal = mibEntry["DEFVAL"];
+
+		if ( !syntax ) {
+			if ( mibEntry.MACRO == "NOTIFICATION-TYPE" ) {
+
+				var curTrap = {
+					name: mibEntry.ObjectName,
+					OID: mibEntry.OID,
+					objects: mibEntry.OBJECTS
+				};
+
+				traps[mibEntry.OID] = curTrap;
+			}
+		}
+	}
+	return traps
+};
+
 ModuleStore.prototype.getSyntaxTypes = function () {
 	var syntaxTypes = {};
 	Object.assign (syntaxTypes, ObjectType);


### PR DESCRIPTION
Created a funtion getTrapOIDsForModule which parses a module and creates mapping between the OID and the trap name for every object of type NOTIFICATION-TYPE.

The use if this function is for applications which receive traps and need to identify them by the name defined in the MIB file.

At the time I needed this functionality quite some time ago, I could not find this functionality in the library. I only briefly checked now and think it is still not available. The function is quite isolated and should not impact any other functionality. Of course you may decide it does not fit in the library. I think I copied and trimmed some other function to create this one.