### PR TITLE
Fix session.subtree callback: abort for return value true

### DIFF
--- a/index.js
+++ b/index.js
@@ -2296,8 +2296,11 @@ function subtreeCb (req, varbinds) {
 		}
 	}
 
-	if (varbinds.length > 0)
-		req.feedCb (varbinds);
+	if (varbinds.length > 0) {
+		if (req.feedCb (varbinds)) {
+			done = 1;
+		}
+	}
 
 	if (done)
 		return true;


### PR DESCRIPTION
Trivial fix for issue: [240 - session.subtree: feedCallback return value not checked](https://github.com/markabrahams/node-net-snmp/issues/240)