### PR TITLE
Add MIB parsing support for out-of-order object definitions

### DIFF
--- a/lib/mib.js
+++ b/lib/mib.js
@@ -346,6 +346,7 @@ var MIB = function (dir) {
                     var Symbols = this.SymbolBuffer[ModuleName];
                     var Object = Module;
                     var MACROName = '';
+                    let unresolvedObjects = [];
                     for (var i = 0; i < Symbols.length; i++) {
                         switch (Symbols[i]) {
                             case '::=': //new OBJECT to define
@@ -372,9 +373,14 @@ var MIB = function (dir) {
                                             Object[Symbols[i - 2]]['OID'] = '0.0';
                                             Object[Symbols[i - 2]]['NameSpace'] = 'null';
                                         } else {
-                                            const { oidString, nameString } = this.getOidAndNamePaths(Object[Symbols[i - 2]]['OBJECT IDENTIFIER'], Symbols[i - 2], ModuleName);
+                                            const { oidString, nameString, unresolvedObject } = this.getOidAndNamePaths(Object[Symbols[i - 2]]['OBJECT IDENTIFIER'], Symbols[i - 2], ModuleName);
                                             Object[Symbols[i - 2]]['OID'] = oidString;
                                             Object[Symbols[i - 2]]['NameSpace'] = nameString;
+                                            if (unresolvedObject) {
+                                                if ( ! unresolvedObjects.includes(unresolvedObject) ) {
+                                                    unresolvedObjects.push(unresolvedObject);
+                                                }
+                                            }
                                             // Object[Symbols[i - 2]]['ModuleName'] = ModuleName;
                                             // Object[Symbols[i - 2]]['ObjectName'] = Symbols[i - 2];
                                         }
@@ -531,11 +537,14 @@ var MIB = function (dir) {
                                             Object[Symbols[r - 1]]['OID'] = '0.0';
                                             Object[Symbols[r - 1]]['NameSpace'] = 'null';
                                         } else {
-                                            const { oidString, nameString } = this.getOidAndNamePaths(Object[Symbols[r - 1]]['OBJECT IDENTIFIER'], Symbols[r - 1], ModuleName);
+                                            const { oidString, nameString, unresolvedObject } = this.getOidAndNamePaths(Object[Symbols[r - 1]]['OBJECT IDENTIFIER'], Symbols[r - 1], ModuleName);
                                             Object[Symbols[r - 1]]['OID'] = oidString;
                                             Object[Symbols[r - 1]]['NameSpace'] = nameString;
-                                            // Object[Symbols[r - 1]]['ModuleName'] = ModuleName;
-                                            // Object[Symbols[r - 1]]['ObjectName'] = Symbols[r - 1];
+                                            if (unresolvedObject) {
+                                                if ( ! unresolvedObjects.includes(unresolvedObject) ) {
+                                                    unresolvedObjects.push(unresolvedObject);
+                                                }
+                                            }
                                         }
                                         if ( Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'] &&
                                                 Object[Symbols[r - 1]]['REVISIONS-DESCRIPTIONS'].length == 1 &&
@@ -642,6 +651,29 @@ var MIB = function (dir) {
                         }
 
 
+                    }
+                    // attempt OID/namespace reconstruction for unresolved objects, as parsing has finished
+                    if (unresolvedObjects.length > 0) {
+                        for (const unresolved of unresolvedObjects) {
+                            const obj = this.Modules[ModuleName][unresolved];
+                            
+                            const { oidString, nameString, unresolvedObject } = this.getOidAndNamePaths(obj['OBJECT IDENTIFIER'], unresolved, ModuleName);
+                            this.Modules[ModuleName][unresolved].NameSpace = nameString;
+                            this.Modules[ModuleName][unresolved].OID = oidString;
+
+                            // unresolvedObject is only returned if still unable to resolve (likely due to error in MIB)
+                            // unresolved OID will propagate to all children as well
+                            if (unresolvedObject) {
+                                if (obj.NameSpace) {
+                                    const unresolvedParent = obj.NameSpace.split('.')[1];
+                                    if (unresolvedParent !== obj.ObjectName) {
+                                        console.warn(`Unable to mount node '${obj.ObjectName}', cannot resolve parent object '${unresolvedParent}'.`);
+                                        continue;
+                                    }
+                                }
+                                console.warn(`Unable to mount node '${obj.ObjectName}', cannot resolve object identifier '${obj['OBJECT IDENTIFIER']}'.`);
+                            }
+                        }
                     }
                 }
             }
@@ -761,6 +793,7 @@ var MIB = function (dir) {
             nameEntries.push(ObjectName);
             let parentOidPrefix;
             let parentNamePrefix;
+            let unresolvedObject;
             if ( parent == 'iso' ) {
                 parentOidPrefix = '1';
                 parentNamePrefix = 'iso';
@@ -780,18 +813,25 @@ var MIB = function (dir) {
                 }
                 if ( ! parentObject ) {
                     // occurs for out-of-order dependencies in a module
-                    // console.warn('Parent object not found for ' + parent);
+                    // return partial OID/namespace and name of unresolved object
+                    unresolvedObject = ObjectName;
                     return {
-                        oidString: '',
-                        nameString: ''
+                        oidString: '.' + oidEntries.join('.'),
+                        nameString: '.' + nameEntries.join('.'),
+                        unresolvedObject
                     };
+                }
+                // occurs for all children of an unresolved node
+                if ( parentObject.OID.startsWith('.') ) {
+                    unresolvedObject = ObjectName;
                 }
                 parentOidPrefix = parentObject['OID'];
                 parentNamePrefix = parentObject['NameSpace'];
             }
             return {
                 oidString: parentOidPrefix + '.' + oidEntries.join('.'),
-                nameString: parentNamePrefix + '.' + nameEntries.join('.')
+                nameString: parentNamePrefix + '.' + nameEntries.join('.'),
+                unresolvedObject: unresolvedObject ?? undefined
             };
         }
     });


### PR DESCRIPTION
Add support for out-of-order object definitions within a MIB module by:

- Adding array `unresolvedObjects` to keep track of unresolved object names during parsing.
- Changing `getOidAndNamePaths()` to always return partial OID/namespace. Unresolved object name is returned as `unresolvedObject` if parent is not found, or parent has partial OID/namespace (ancestor of a broken parent object).
- Adding `unresolvedObject` to array `unresolvedObjects` if it is returned.
- Iterating through array `unresolvedObjects` after parsing has finished (if not empty), and attempting OID/namespace reconstruction.
- Printing console warnings for all objects that are affected by an unresolvable OID lineage (only if reconstruction fails).


These changes only affect cases where parent is not found. Any ordinary compiling should be unaffected.