### PR TITLE
Fix for error with negative ints on AgentX

### DIFF
--- a/index.js
+++ b/index.js
@@ -5685,7 +5685,9 @@ AgentXPdu.writeVarBind = function (buffer, varbind) {
 	if (varbind.type && varbind.oid) {
 
 		switch (varbind.type) {
-			case ObjectType.Integer: // also Integer32
+			case ObjectType.Integer: // also Integer32 (signed 32-bit)
+				buffer.writeInt32BE (varbind.value);
+				break;
 			case ObjectType.Counter: // also Counter32
 			case ObjectType.Gauge: // also Gauge32 & Unsigned32
 			case ObjectType.TimeTicks:


### PR DESCRIPTION
Came across issue with the marshalling of INTEGER/Integer32 values with AgentX.  Negative values are rejected by the buffer.writeUInt32BE(val) call as out of range (which is correct for UInteger32 and the like, but not for signed 32 bit integers).
Simple fix to switch to using buffer.writeInt32BE(val) for the Integer type.