### PR TITLE
ModuleStore: Allow to configure base modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3434,7 +3434,8 @@ Receiver.create = function (options, callback) {
 	return receiver;
 };
 
-var ModuleStore = function () {
+var ModuleStore = function (baseModules) {
+	this.baseModules = baseModules;
 	this.parser = mibparser ();
 	this.translations = {
 		oidToPath: {},
@@ -3524,7 +3525,7 @@ ModuleStore.prototype.getModule = function (moduleName) {
 ModuleStore.prototype.getModules = function (includeBase) {
 	var modules = {};
 	for ( var moduleName of Object.keys(this.parser.Modules) ) {
-		if ( includeBase || ModuleStore.BASE_MODULES.indexOf (moduleName) == -1 ) {
+		if ( includeBase || this.baseModules.indexOf (moduleName) == -1 ) {
 			modules[moduleName] = this.parser.Modules[moduleName];
 		}
 	}
@@ -3534,7 +3535,7 @@ ModuleStore.prototype.getModules = function (includeBase) {
 ModuleStore.prototype.getModuleNames = function (includeBase) {
 	var modules = [];
 	for ( var moduleName of Object.keys(this.parser.Modules) ) {
-		if ( includeBase || ModuleStore.BASE_MODULES.indexOf (moduleName) == -1 ) {
+		if ( includeBase || this.baseModules.indexOf (moduleName) == -1 ) {
 			modules.push (moduleName);
 		}
 	}
@@ -3708,7 +3709,7 @@ ModuleStore.prototype.getProvidersForModule = function (moduleName) {
 };
 
 ModuleStore.prototype.loadBaseModules = function () {
-	for ( var mibModule of ModuleStore.BASE_MODULES ) {
+	for ( var mibModule of this.baseModules ) {
 		this.parser.Import (__dirname + "/lib/mibs/" + mibModule + ".mib");
 	}
 	this.parser.Serialize ();
@@ -3792,8 +3793,8 @@ ModuleStore.prototype.translate = function (name, destinationFormat) {
 	}
 };
 
-ModuleStore.create = function () {
-	var store = new ModuleStore ();
+ModuleStore.create = function (options) {
+	const store = new ModuleStore (options?.baseModules ?? ModuleStore.BASE_MODULES);
 	store.loadBaseModules ();
 	return store;
 };


### PR DESCRIPTION
This provides a way to workaround the change of behaviour introduced by the deferred registration update.  Constraints for SNMPv2-TC defined textual conventions like DisplayString seem to get preempted by the subsequent definitions as plain OCTET STRING in RFC MIBs.

This feature allows the user to select upon which base MIBs they depend explicitly so as not to get any surprises or unexpected type overrides.

Example usage to select just the SNMPv2 MIBs:
```js
   snmp.createModuleStore({
     baseModules: [
       'SNMPv2-SMI',
       'SNMPv2-CONF',
       'SNMPv2-TC',
       'SNMPv2-MIB',
     ],
   });
```