### PR TITLE
Create Options.dgramModule to All Use of Custom UDP Socket Module

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -100,6 +100,7 @@ var session = snmp.createSession ("127.0.0.1", "public", options);
 * `version` - `snmp.Version1`或`snmp.Version2c`，默认为`snmp.Version1`。
 * "backwardsGetNexts"----允许进行GetNext操作的布尔值，以检索词法上在前的OIDs。
 * `idBitsSize` - `16`或`32`，默认为`32`。用来减少生成的id的大小，以便与一些旧设备兼容。
+* `dgramModule` – 一个与 Node.js [`dgram`](https://nodejs.org/api/dgram.html) 模块接口兼容的模块。您可以通过提供自定义或包装的 `dgram` 实现来扩展或覆盖默认的 UDP 套接字行为。
 
 当一个会话结束后，应该关闭它。
 

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ var options = {
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
     idBitsSize: 32,
-    udpModule: dgram
+    dgramModule: dgram
 };
 
 var session = snmp.createSession ("127.0.0.1", "public", options);

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Actions
 - `4 -  ECouldNotDecrypt`
 - `5 -  EAuthFailure`
 - `6 -  EReqResOidNoMatch`
-- `7 -  (no longer used)
+- `7 -  (no longer used)`
 - `8 -  EOutOfOrder`
 - `9 -  EVersionNoMatch`
 - `10 -  ECommunityNoMatch`
@@ -588,7 +588,8 @@ var options = {
     version: snmp.Version1,
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
-    idBitsSize: 32
+    idBitsSize: 32,
+    udpModule: dgram
 };
 
 var session = snmp.createSession ("127.0.0.1", "public", options);
@@ -620,6 +621,10 @@ is an object, and can contain the following items:
    requests and responses, defaults to `false`
  * `idBitsSize` - Either `16` or `32`, defaults to `32`.  Used to reduce the size
     of the generated id for compatibility with some older devices.
+ * `dgramModule` – A module that is interface-compatible with the Node.js [`dgram`](https://nodejs.org/api/dgram.html) module.
+    This can be used to extend or override the default UDP socket behavior by supplying
+    a custom or wrapped implementation of `dgram`.
+         
 
 When a session has been finished with it should be closed:
 

--- a/index.js
+++ b/index.js
@@ -2042,7 +2042,8 @@ var Session = function (target, authenticator, options) {
 	this.reqs = {};
 	this.reqCount = 0;
 
-	this.dgram = dgram.createSocket (this.transport);
+	const dgramMod = options.dgramModule || dgram;
+	this.dgram = dgramMod.createSocket (this.transport);
 	this.dgram.unref();
 
 	var me = this;
@@ -3060,7 +3061,8 @@ Listener.prototype.startListening = function () {
 	var me = this;
 	this.sockets = {};
 	for ( const socketOptions of this.socketOptions ) {
-		const socket = dgram.createSocket (socketOptions.transport);
+		const dgramMod = options.dgramModule || dgram;
+		const socket = dgramMod.createSocket (socketOptions.transport);
 		socket.on ("error", me.receiver.callback);
 		socket.bind (socketOptions.port, socketOptions.address);
 		socket.on ("message", me.callback.bind (me.receiver, socket));


### PR DESCRIPTION
Context: markabrahams/node-net-snmp/#284

This PR adds support for supplying a custom UDP socket implementation via an optional options.dgramModule parameter. This module must be compatible with the Node.js dgram API. This change is fully backward-compatible and does not affect any existing behavior when options.dgramModule is not provided.

Benefits:
- Framework Compatibility: Enables integration with environments that manage UDP sockets differently (e.g., shared socket management or sandboxed platforms).
- Enhanced Extensibility: Developers can inject wrapped or extended versions of dgram to add instrumentation, debugging, monitoring, logging, or special routing behaviors.
- Multi-Instance Support: Supports scenarios where multiple agents/modules must share access to a fixed port (e.g., when devices send traps to a hardcoded port).

Use Cases:
- Replacing dgram with a shared socket manager, such as in modular automation platforms or cloud-hosted runtimes.
- Injecting a mocked socket for testing SNMP session logic without actual network traffic.
- Implementing a loopback or simulated transport layer for development environments.

