### PR TITLE
Follow-up to #285: Create Options.dgramModule to All Use of Custom UDP Socket Module

### DIFF
--- a/README.cn.md
+++ b/README.cn.md
@@ -100,6 +100,7 @@ var session = snmp.createSession ("127.0.0.1", "public", options);
 * `version` - `snmp.Version1`或`snmp.Version2c`，默认为`snmp.Version1`。
 * "backwardsGetNexts"----允许进行GetNext操作的布尔值，以检索词法上在前的OIDs。
 * `idBitsSize` - `16`或`32`，默认为`32`。用来减少生成的id的大小，以便与一些旧设备兼容。
+* `dgramModule` – 一个与 Node.js [`dgram`](https://nodejs.org/api/dgram.html) 模块接口兼容的模块。您可以通过提供自定义或包装的 `dgram` 实现来扩展或覆盖默认的 UDP 套接字行为。
 
 当一个会话结束后，应该关闭它。
 

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ var options = {
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
     idBitsSize: 32,
-    udpModule: dgram
+    dgramModule: dgram
 };
 
 var session = snmp.createSession ("127.0.0.1", "public", options);

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ Actions
 - `4 -  ECouldNotDecrypt`
 - `5 -  EAuthFailure`
 - `6 -  EReqResOidNoMatch`
-- `7 -  (no longer used)
+- `7 -  (no longer used)`
 - `8 -  EOutOfOrder`
 - `9 -  EVersionNoMatch`
 - `10 -  ECommunityNoMatch`
@@ -588,7 +588,8 @@ var options = {
     version: snmp.Version1,
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
-    idBitsSize: 32
+    idBitsSize: 32,
+    udpModule: dgram
 };
 
 var session = snmp.createSession ("127.0.0.1", "public", options);
@@ -620,6 +621,10 @@ is an object, and can contain the following items:
    requests and responses, defaults to `false`
  * `idBitsSize` - Either `16` or `32`, defaults to `32`.  Used to reduce the size
     of the generated id for compatibility with some older devices.
+ * `dgramModule` – A module that is interface-compatible with the Node.js [`dgram`](https://nodejs.org/api/dgram.html) module.
+    This can be used to extend or override the default UDP socket behavior by supplying
+    a custom or wrapped implementation of `dgram`.
+         
 
 When a session has been finished with it should be closed:
 

--- a/index.js
+++ b/index.js
@@ -3039,6 +3039,7 @@ var Listener = function (options, receiver) {
 	// this.port = options.port || 161;
 	// this.address = options.address;
 	this.disableAuthorization = options.disableAuthorization || false;
+	this.dgramModule = options.dgramModule || dgram;
 	if ( options.sockets ) {
 		this.socketOptions = options.sockets;
 	} else {
@@ -3061,7 +3062,7 @@ Listener.prototype.startListening = function () {
 	var me = this;
 	this.sockets = {};
 	for ( const socketOptions of this.socketOptions ) {
-		const dgramMod = options.dgramModule || dgram;
+		const dgramMod = this.dgramModule;
 		const socket = dgramMod.createSocket (socketOptions.transport);
 		socket.on ("error", me.receiver.callback);
 		socket.bind (socketOptions.port, socketOptions.address);

--- a/index.js
+++ b/index.js
@@ -2042,7 +2042,8 @@ var Session = function (target, authenticator, options) {
 	this.reqs = {};
 	this.reqCount = 0;
 
-	this.dgram = dgram.createSocket (this.transport);
+	const dgramMod = options.dgramModule || dgram;
+	this.dgram = dgramMod.createSocket (this.transport);
 	this.dgram.unref();
 
 	var me = this;
@@ -3060,7 +3061,8 @@ Listener.prototype.startListening = function () {
 	var me = this;
 	this.sockets = {};
 	for ( const socketOptions of this.socketOptions ) {
-		const socket = dgram.createSocket (socketOptions.transport);
+		const dgramMod = options.dgramModule || dgram;
+		const socket = dgramMod.createSocket (socketOptions.transport);
 		socket.on ("error", me.receiver.callback);
 		socket.bind (socketOptions.port, socketOptions.address);
 		socket.on ("message", me.callback.bind (me.receiver, socket));

--- a/test/dgram-module.test.js
+++ b/test/dgram-module.test.js
@@ -1,0 +1,71 @@
+const assert = require('assert');
+const snmp = require('../');
+
+describe('Custom dgram module support', function () {
+	it('should use custom dgram module in Session', function (done) {
+		let createSocketCalled = false;
+		const mockDgram = {
+			createSocket: function (transport) {
+				createSocketCalled = true;
+				assert.equal(transport, 'udp4');
+				
+				// Return a mock socket
+				return {
+					unref: function () {},
+					on: function () {},
+					bind: function () {},
+					close: function () {}
+				};
+			}
+		};
+
+		const session = snmp.createSession('127.0.0.1', 'public', {
+			dgramModule: mockDgram
+		});
+
+		assert(createSocketCalled, 'Custom dgram module createSocket should have been called');
+		session.close();
+		done();
+	});
+
+	it('should use custom dgram module in Receiver', function (done) {
+		let createSocketCalled = false;
+		const mockDgram = {
+			createSocket: function (transport) {
+				createSocketCalled = true;
+				assert.equal(transport, 'udp4');
+				
+				// Return a mock socket
+				return {
+					on: function () {},
+					bind: function () {},
+					close: function () {},
+					address: function () {
+						return { address: '127.0.0.1', family: 'IPv4', port: 162 };
+					}
+				};
+			}
+		};
+
+		const receiver = snmp.createReceiver({
+			dgramModule: mockDgram,
+			port: 1162
+		}, function () {});
+
+		assert(createSocketCalled, 'Custom dgram module createSocket should have been called');
+		receiver.close();
+		done();
+	});
+
+	it('should fallback to default dgram when no custom module provided', function (done) {
+		// This should not throw an error
+		const session = snmp.createSession('127.0.0.1', 'public', {
+			// No dgramModule specified
+		});
+
+		// Session should be created successfully
+		assert(session);
+		session.close();
+		done();
+	});
+});


### PR DESCRIPTION
@mamanakis - thanks for PR #285 - I've added to it with this:
- I've stored `options.dgramModule || dgram in this.dgramModule` within the Listener constructor and referenced `this.dgramModule` in the `startListening()` method.
- And I've added some very basic tests.

Would you be willing to add documentation to the README for the new feature? If so, you can either:
- Push directly to this branch (you have access), or
- Comment here with suggested content and I’ll add it on your behalf