### PR TITLE
Add option to ignore int range checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,8 @@ var options = {
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
     idBitsSize: 32,
-    dgramModule: dgram
+    dgramModule: dgram,
+    strictIntRangeChecks: false
 };
 
 var session = snmp.createSession ("127.0.0.1", "public", options);
@@ -624,6 +625,10 @@ is an object, and can contain the following items:
  * `dgramModule` – A module that is interface-compatible with the Node.js [`dgram`](https://nodejs.org/api/dgram.html) module.
     This can be used to extend or override the default UDP socket behavior by supplying
     a custom or wrapped implementation of `dgram`.
+ * `strictIntRangeChecks` - boolean to enable min/max range checks in `readInt32` and `readUint32`.
+   When set to `true`, out-of-range values will throw, otherwise they will be logged via debug if `debug` is enabled.
+   Note that the option is toggled at module level when a session is created. If you create multiple sessions 
+   with conflicting settings, the most recently created session’s setting will apply process-wide.
          
 
 When a session has been finished with it should be closed:
@@ -650,7 +655,8 @@ var options = {
     backwardsGetNexts: true,
     reportOidMismatchErrors: false,
     idBitsSize: 32,
-    context: ""
+    context: "",
+    strictIntRangeChecks: false
 };
 
 // Example user

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const mibparser = require ("./lib/mib");
 const Buffer = require('buffer').Buffer;
 
 var DEBUG = false;
+var STRICT_INT_RANGE_CHECKS = false;
 
 const MIN_SIGNED_INT32 = -2147483648;
 const MAX_SIGNED_INT32 = 2147483647;
@@ -408,7 +409,12 @@ function readInt32 (buffer) {
 		throw new TypeError('Value read as integer ' + parsedInt + ' is not an integer');
 	}
 	if ( parsedInt < MIN_SIGNED_INT32 || parsedInt > MAX_SIGNED_INT32 ) {
-		throw new RangeError('Read integer ' + parsedInt + ' is outside the signed 32-bit range');
+		const errorMessage = 'Read integer ' + parsedInt + ' is outside the signed 32-bit range';
+		if ( STRICT_INT_RANGE_CHECKS ) {
+			throw new RangeError(errorMessage);
+		} else {
+			debug(errorMessage);
+		}
 	}
 	return parsedInt;
 }
@@ -420,7 +426,12 @@ function readUint32 (buffer) {
 	}
 	parsedInt = (parsedInt>>>0);
 	if ( parsedInt < MIN_UNSIGNED_INT32 || parsedInt > MAX_UNSIGNED_INT32 ) {
-		throw new RangeError('Read integer ' + parsedInt + ' is outside the unsigned 32-bit range');
+		const errorMessage = 'Read integer ' + parsedInt + ' is outside the unsigned 32-bit range';
+		if ( STRICT_INT_RANGE_CHECKS ) {
+			throw new RangeError(errorMessage);
+		} else {
+			debug(errorMessage);
+		}
 	}
 	return parsedInt;
 }
@@ -2056,6 +2067,11 @@ var Session = function (target, authenticator, options) {
 	this.reportOidMismatchErrors = (typeof options.reportOidMismatchErrors !== 'undefined')
             ? options.reportOidMismatchErrors
             : false;
+
+	// Enable/disable min/max checks on readInt32/readUint32
+	if ( options?.strictIntRangeChecks !== undefined ) {
+		STRICT_INT_RANGE_CHECKS = !!options.strictIntRangeChecks;
+	}
 
 	DEBUG |= options.debug;
 


### PR DESCRIPTION
Somewhat non-ideal way to handle the issue in https://github.com/markabrahams/node-net-snmp/issues/293

Would be better to make the option apply per session but given the way the varbind decoding is implemented it is difficult to tie that back to the session. So I'm putting this up for discussion / consideration at least.